### PR TITLE
Working on v7.1.0...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ IMP: Screen: Auto vacuum (No more than 750 lines)
 IMP: Command 'repeat': Try to be nice with the main thread
 IMP: Command 'fuzz': Support one2many fields and other improvements
 IMP: ParameterReader: Now can use slashes to avoid double quotes grouping (Example: "This \"is\" an example")
+IMP: Handle big results: split current query to not block/crash the browser
+IMP: Now can set default values for positional replacements (Example: $1[defaul text value] or $1[42])
 
 ADD: Command 'mute': Runs the command only printing errors. (Useful with the 'repeat' command)
 ADD: Command 'count': Get the number of records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ IMP: Screen: Auto vacuum (No more than 750 lines)
 IMP: Command 'repeat': Try to be nice with the main thread
 
 ADD: Command 'mute': Runs the command only printing errors. (Useful with the 'repeat' command)
+ADD: Command 'count': Get the number of records
+ADD: New parameter generator: $FLOAT
+ADD: Prompt changes the color per host (locahost doesn't have any color)
 
 FIX: Changed some calls using the old 'print' call.
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ ADD: Command 'exportfile': Exports the command result to a text file
 ADD: New parameter generator: $FLOAT
 ADD: Prompt changes the color per host (locahost doesn't have any color)
 
-FIX: Changed some calls using the old 'print' call.
+FIX: Changed some calls using the old 'print' call
 FIX: Command 'caf': Now can use 'fields' parameter
+FIX: Shadow Input: Correct sync. with input scroll left
 ```
 
 **7.0.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+**7.1.0**
+
+```
+IMP: Command 'caf': Sorted by field name
+```
+
 **7.0.0**
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ```
 IMP: Command 'caf': Sorted by field name
+IMP: Screen: Use less nodes
 ```
 
 **7.0.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ IMP: Command 'caf': Sorted by field name
 IMP: Screen: Use less nodes
 IMP: Screen: Auto vacuum (No more than 750 lines)
 IMP: Command 'repeat': Try to be nice with the main thread
+IMP: Command 'fuzz': Support one2many fields and other improvements
+IMP: ParameterReader: Now can use slashes to avoid double quotes grouping (Example: "This \"is\" an example")
 
 ADD: Command 'mute': Runs the command only printing errors. (Useful with the 'repeat' command)
 ADD: Command 'count': Get the number of records
+ADD: Command 'exportfile': Exports the command result to a text file
 ADD: New parameter generator: $FLOAT
 ADD: Prompt changes the color per host (locahost doesn't have any color)
 
 FIX: Changed some calls using the old 'print' call.
+FIX: Command 'caf': Now can use 'fields' parameter
 ```
 
 **7.0.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ```
 IMP: Command 'caf': Sorted by field name
 IMP: Screen: Use less nodes
+IMP: Screen: Auto vacuum (No more than 750 lines)
+IMP: Command 'repeat': Try to be nice with the main thread
+
+ADD: Command 'mute': Runs the command only printing errors. (Useful with the 'repeat' command)
+
+FIX: Changed some calls using the old 'print' call.
 ```
 
 **7.0.0**

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ You can toggle terminal using one of these options:
 
 - This extension have a "preferences" page where you can add commands to run on
   every session. This is useful for example to load a remote script to extend
-  the 'terminal' features.
+  the 'terminal' features or declare custom aliases.
 - This extension uses an internal context to extend the 'user context'. This
   'terminal context' has by default the key 'active_test' = false (see issue #14
   to get more information). This context only affects to terminal operations.
+- The maximum buffered screen lines is set to 750. So, you can't see more than
+  749 records in the same query. This is necessary to avoid have a lot of
+  nodes... One of the problems of use HTML elements to render the output :/
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,14 @@ You can toggle terminal using one of these options:
 
 ## Advance Usage
 
+#### + Parameter Generators
+
 You can use "parameter generator" to create values.
 
 | Generator    | Arguments | Default   | Description                                                                   |
 | ------------ | --------- | --------- | ----------------------------------------------------------------------------- |
 | \$STR        | min,max   | max = min | Generates a random string with a length between the given min and max         |
+| \$FLOAT      | min,max   | max = min | Generates a random float between the given min and max                        |
 | \$INT        | min,max   | max = min | Generates a random int between the given min and max                          |
 | \$INTSEQ     | min,max   | max = min | Generates a list of int's starting from min to max                            |
 | \$INTITER    | min,step  | step = 1  | Generates a consecutive int starting from min (useful with 'repeat' command)  |
@@ -103,7 +106,7 @@ You can use "parameter generator" to create values.
 | \$NOW        |           |           | Gets the current date time                                                    |
 | \$TZNOW      |           |           | Gets the current date time (time zone format)                                 |
 
-The anatomy of a generator is: `$type[min,max]`, `$type[min]` or `$type`
+The anatomy of a generator is: `$type[min,max]`, `$type[max]` or `$type`
 
 For example:
 
@@ -112,6 +115,22 @@ For example:
 - print the current time: `print $NOWTIME`
 
 > Notice that 'date' min and max are the milliseconds since 1970/01/01
+
+#### + Positional replacements for aliases
+
+You can define aliases to call commands with predefined values. This command can
+use positional replacements.
+
+The anatomy of a positional replacement is: `$num[default_value]` or `$num`
+
+For example:
+
+- First positional replacement (without default value = empty):
+  `alias my_alias print Hello, $1`
+- Fist position replacement with default value 'world':
+  `alias my_alias print Hello, $1[world]`
+- A somewhat more complex:
+  `alias search_mod search ir.module.module display_name "[['name', '=', '$1'], ['state', '=', '$2[installed]']]"`
 
 ---
 

--- a/docs/example_funcs.js
+++ b/docs/example_funcs.js
@@ -43,18 +43,20 @@ odoo.define("terminal.MyFuncs", function(require) {
             param_c = "DefaultValue",
             param_d = -1
         ) {
-            this.print("Hello, World!");
-            this.eprint("ParamA (String): " + param_a);
-            this.eprint("ParamB (Int): " + param_b);
-            this.eprint("ParamC (Optional String): " + param_c);
-            this.eprint("ParamD (Optional Int): " + param_d);
+            this.screen.print("Hello, World!");
+            this.screen.eprint("ParamA (String): " + param_a);
+            this.screen.eprint("ParamB (Int): " + param_b);
+            this.screen.eprint("ParamC (Optional String): " + param_c);
+            this.screen.eprint("ParamD (Optional Int): " + param_d);
 
             if (param_b instanceof Number) {
-                this.print("ParamB is a Number!");
+                this.screen.print("ParamB is a Number!");
             }
 
             if (param_a !== param_c) {
-                this.printError("Invalid! ParamA need be the same as ParamC");
+                this.screen.printError(
+                    "Invalid! ParamA need be the same as ParamC"
+                );
             }
 
             return Promise.resolve();

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -101,10 +101,6 @@
     content: "\A";
     white-space: pre;
 }
-.o_terminal div#terminal_screen .line-br::before {
-    content: "\A";
-    white-space: pre;
-}
 
 .o_terminal div#terminal_screen .line-array {
     margin-left: 1em;

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -97,6 +97,15 @@
     margin: 0;
 }
 
+.o_terminal div#terminal_screen .line-br::after {
+    content: "\A";
+    white-space: pre;
+}
+.o_terminal div#terminal_screen .line-br::before {
+    content: "\A";
+    white-space: pre;
+}
+
 .o_terminal div#terminal_screen .line-array {
     margin-left: 1em;
 }

--- a/odoo/js/core/parameter_generator.js
+++ b/odoo/js/core/parameter_generator.js
@@ -54,6 +54,7 @@ odoo.define("terminal.core.ParameterGenerator", function(require) {
 
         init: function() {
             this._generators = {
+                FLOAT: this.generateFloat.bind(this),
                 INT: this.generateInt.bind(this),
                 INTSEQ: this.generateIntSeq.bind(this),
                 INTITER: this._doIntIter.bind(this),
@@ -131,6 +132,17 @@ odoo.define("terminal.core.ParameterGenerator", function(require) {
             return `https://www.${url}.${ext}`
                 .replaceAll(" ", "")
                 .toLowerCase();
+        },
+
+        generateFloat: function(min, max) {
+            if (typeof min === "undefined") {
+                return false;
+            }
+            const min_s = _.isUndefined(max) ? 0 : Number(min);
+            const max_s = _.isUndefined(max) ? Number(min) : Number(max);
+            return Number(
+                (Math.random() * (max_s - min_s + 1.0) + min_s).toFixed(2)
+            );
         },
 
         generateInt: function(min, max) {

--- a/odoo/js/core/parameter_reader.js
+++ b/odoo/js/core/parameter_reader.js
@@ -22,7 +22,7 @@ odoo.define("terminal.core.ParameterReader", function(require) {
             };
             this._regexSanitize = new RegExp("'", "g");
             this._regexParams = new RegExp(
-                /(["'])((?:(?=(\\?))\2.)*?)\1|[^\s]+/,
+                /(["'])(?:(?=(\\?))\2.)*?\1|[^\s]+/,
                 "g"
             );
             this._regexArgs = new RegExp(/[l?*]/);
@@ -56,9 +56,10 @@ odoo.define("terminal.core.ParameterReader", function(require) {
                 if (item[0] === '"' || item[0] === "'") {
                     nvalue = item.substr(1, item.length - 2);
                 }
-                return cmd_def.sanitized
+                return (cmd_def.sanitized
                     ? this._sanitizeString(nvalue)
-                    : nvalue;
+                    : nvalue
+                ).replaceAll("\\", "");
             });
 
             if (cmd_def.generators) {

--- a/odoo/js/core/parameter_reader.js
+++ b/odoo/js/core/parameter_reader.js
@@ -5,6 +5,7 @@ odoo.define("terminal.core.ParameterReader", function(require) {
     "use strict";
 
     const ParameterGenerator = require("terminal.core.ParameterGenerator");
+    const Utils = require("terminal.core.Utils");
     const Class = require("web.Class");
 
     /**
@@ -56,10 +57,9 @@ odoo.define("terminal.core.ParameterReader", function(require) {
                 if (item[0] === '"' || item[0] === "'") {
                     nvalue = item.substr(1, item.length - 2);
                 }
-                return (cmd_def.sanitized
-                    ? this._sanitizeString(nvalue)
-                    : nvalue
-                ).replaceAll("\\", "");
+                return cmd_def.sanitized
+                    ? this._sanitizeString(Utils.unescapeSlashes(nvalue))
+                    : nvalue;
             });
 
             if (cmd_def.generators) {

--- a/odoo/js/core/screen.js
+++ b/odoo/js/core/screen.js
@@ -14,6 +14,8 @@ odoo.define("terminal.core.Screen", function(require) {
     const Screen = AbstractScreen.extend({
         PROMPT: ">",
 
+        _line_selector:
+            "> span .print-table tr, > span:has(.print-table tbody:empty), > span:not(:has(.print-table))",
         _max_lines: 750,
 
         init: function() {
@@ -195,6 +197,29 @@ odoo.define("terminal.core.Screen", function(require) {
             );
         },
 
+        printRecords: function(model, records) {
+            let tbody = "";
+            const columns = ["id"];
+            const len = records.length;
+            for (let x = 0; x < len; ++x) {
+                const item = records[x];
+                tbody += "<tr>";
+                tbody += this._templates.render("TABLE_SEARCH_ID", {
+                    id: item.id,
+                    model: model,
+                });
+                for (const field in item) {
+                    if (field === "id") {
+                        continue;
+                    }
+                    columns.push(field);
+                    tbody += `<td>${item[field]}</td>`;
+                }
+                tbody += "</tr>";
+            }
+            this.printTable(_.unique(columns), tbody);
+        },
+
         /* PRIVATE */
         _getTerminalLine: function(msg, cls) {
             const msg_type = typeof msg;
@@ -220,9 +245,7 @@ odoo.define("terminal.core.Screen", function(require) {
         },
 
         _vacuum: function() {
-            const $lines = this.$screen.find(
-                "> span .print-table tr, > span:has(.print-table tbody:empty), > span:not(:has(.print-table))"
-            );
+            const $lines = this.$screen.find(this._line_selector);
             const diff = $lines.length - this._max_lines;
             if (diff > 0) {
                 $lines.slice(0, diff).remove();

--- a/odoo/js/core/screen.js
+++ b/odoo/js/core/screen.js
@@ -96,7 +96,10 @@ odoo.define("terminal.core.Screen", function(require) {
         },
 
         print: function(msg, enl, cls) {
-            const scls = enl ? cls || "" : `line-br ${cls}`;
+            let scls = cls || "";
+            if (!enl) {
+                scls = `line-br ${scls}`;
+            }
             this.printHTML(this._getTerminalLine(msg, scls));
         },
 
@@ -214,7 +217,9 @@ odoo.define("terminal.core.Screen", function(require) {
         },
 
         _vacuum: function() {
-            const $lines = this.$screen.find("> span");
+            const $lines = this.$screen.find(
+                "> span .print-table tr, > span:has(.print-table tbody:empty), > span:not(:has(.print-table))"
+            );
             const diff = $lines.length - this._max_lines;
             if (diff > 0) {
                 $lines.slice(0, diff).remove();

--- a/odoo/js/core/screen.js
+++ b/odoo/js/core/screen.js
@@ -17,6 +17,7 @@ odoo.define("terminal.core.Screen", function(require) {
         init: function() {
             this._super.apply(this, arguments);
             this._templates = new TemplateManager();
+            this._linesCounter = 0;
         },
 
         start: function() {
@@ -92,34 +93,27 @@ odoo.define("terminal.core.Screen", function(require) {
 
         print: function(msg, enl, cls) {
             const msg_type = typeof msg;
+            const scls = enl ? cls || "" : `line-br ${cls}`;
             if (msg_type === "object") {
                 if (msg instanceof Text) {
                     this.printHTML(
-                        $(msg).wrap(
-                            `<span class='line-text ${cls || ""}'></span>`
-                        )
+                        $(msg).wrap(`<span class='line-text ${scls}'></span>`)
                     );
                 } else if (msg instanceof Array) {
                     const l = msg.length;
                     let html_to_print = "";
                     for (let x = 0; x < l; ++x) {
-                        html_to_print += `<span class='line-array ${cls ||
-                            ""}'>${msg[x]}</span><br>`;
+                        html_to_print += `<span class='line-array ${scls}'>${msg[x]}</span>`;
                     }
                     this.printHTML(html_to_print);
                 } else {
                     this.printHTML(
-                        `<span class='line-object ${cls || ""}'>` +
-                            `${this._prettyObjectString(msg)}</span><br>`
+                        `<span class='line-object ${scls}'>` +
+                            `${this._prettyObjectString(msg)}</span>`
                     );
                 }
             } else {
-                this.printHTML(
-                    `<span class='line-text ${cls || ""}'>${msg}</span>`
-                );
-            }
-            if (!enl) {
-                this.printHTML("<br>");
+                this.printHTML(`<span class='line-text ${scls}'>${msg}</span>`);
             }
         },
 

--- a/odoo/js/core/screen.js
+++ b/odoo/js/core/screen.js
@@ -67,7 +67,10 @@ odoo.define("terminal.core.Screen", function(require) {
 
         updateShadowInput: function(str) {
             this.$shadowInput.val(str);
-            this.$shadowInput.scrollLeft(this.$input.scrollLeft());
+            // Deferred to ensure that has updated values
+            _.defer(() =>
+                this.$shadowInput.scrollLeft(this.$input.scrollLeft())
+            );
         },
 
         preventLostInputFocus: function(ev) {

--- a/odoo/js/core/utils.js
+++ b/odoo/js/core/utils.js
@@ -41,10 +41,27 @@ odoo.define("terminal.core.Utils", function() {
         return parsed_text;
     };
 
+    const save2File = (filename, type, data) => {
+        const blob = new Blob([data], {type: type});
+        if (window.navigator.msSaveOrOpenBlob) {
+            window.navigator.msSaveBlob(blob, filename);
+        } else {
+            const elem = window.document.createElement("a");
+            const objURL = window.URL.createObjectURL(blob);
+            elem.href = objURL;
+            elem.download = filename;
+            document.body.appendChild(elem);
+            elem.click();
+            document.body.removeChild(elem);
+            URL.revokeObjectURL(objURL);
+        }
+    };
+
     return {
         encodeHTML: encodeHTML,
         genHash: genHash,
         hex2rgb: hex2rgb,
         unescapeSlashes: unescapeSlashes,
+        save2File: save2File,
     };
 });

--- a/odoo/js/core/utils.js
+++ b/odoo/js/core/utils.js
@@ -30,9 +30,21 @@ odoo.define("terminal.core.Utils", function() {
         return [r, g, b];
     };
 
+    // See https://stackoverflow.com/a/48855846
+    const unescapeSlashes = text => {
+        let parsed_text = text.replace(/(^|[^\\])(\\\\)*\\$/, "$&\\");
+        try {
+            parsed_text = JSON.parse(`"${parsed_text}"`);
+        } catch (e) {
+            return text;
+        }
+        return parsed_text;
+    };
+
     return {
         encodeHTML: encodeHTML,
         genHash: genHash,
         hex2rgb: hex2rgb,
+        unescapeSlashes: unescapeSlashes,
     };
 });

--- a/odoo/js/core/utils.js
+++ b/odoo/js/core/utils.js
@@ -11,7 +11,28 @@ odoo.define("terminal.core.Utils", function() {
             i => `&#${i.charCodeAt(0)};`
         );
 
+    // See https://stackoverflow.com/a/7616484
+    const genHash = text => {
+        let hash = 0;
+        const len = text.length;
+        for (let i = 0; i < len; ++i) {
+            hash = (hash << 5) - hash + text.charCodeAt(i);
+            // Convert to 32bit integer
+            hash |= 0;
+        }
+        return hash;
+    };
+
+    const hex2rgb = hex => {
+        const r = (hex >> 24) & 0xff;
+        const g = (hex >> 16) & 0xff;
+        const b = (hex >> 8) & 0xff;
+        return [r, g, b];
+    };
+
     return {
         encodeHTML: encodeHTML,
+        genHash: genHash,
+        hex2rgb: hex2rgb,
     };
 });

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -633,12 +633,19 @@ odoo.define("terminal.functions.Common", function(require) {
                 });
         },
 
-        _cmdCheckFieldAccess: function(model, fields = "false") {
+        _cmdCheckFieldAccess: function(model, field_names = false) {
+            let fields = false;
+            if (field_names) {
+                fields =
+                    field_names === "*"
+                        ? false
+                        : this._parameterReader.splitAndTrim(field_names, ",");
+            }
             return rpc
                 .query({
                     method: "fields_get",
                     model: model,
-                    args: [JSON.parse(fields)],
+                    args: [fields],
                     kwargs: {context: this._getContext()},
                 })
                 .then(result => {

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -619,7 +619,7 @@ odoo.define("terminal.functions.Common", function(require) {
                     kwargs: {context: this._getContext()},
                 })
                 .then(result => {
-                    const keys = Object.keys(result);
+                    const keys = Object.keys(result).sort();
                     const fieldParams = [
                         "type",
                         "string",
@@ -630,8 +630,8 @@ odoo.define("terminal.functions.Common", function(require) {
                         "depends",
                     ];
                     let body = "";
-                    const l = keys.length;
-                    for (let x = 0; x < l; ++x) {
+                    const len = keys.length;
+                    for (let x = 0; x < len; ++x) {
                         const field = keys[x];
                         body += "<tr>";
                         body += `<td>${field}</td>`;

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -277,6 +277,29 @@ odoo.define("terminal.functions.Common", function(require) {
                 syntaxis: "",
                 args: "",
             });
+            this.registerCommand("count", {
+                definition:
+                    "Gets number of records from the given model in the selected domain",
+                callback: this._cmdCount,
+                detail:
+                    "Gets number of records from the given model in the selected domain",
+                syntaxis: '<STRING MODEL> "[ARRAY: DOMAIN]"',
+                args: "s?s",
+            });
+        },
+
+        _cmdCount: function(model, domain = "[]") {
+            return rpc
+                .query({
+                    method: "search_count",
+                    model: model,
+                    args: [JSON.parse(domain)],
+                    kwargs: {context: this._getContext()},
+                })
+                .then(result => {
+                    this.screen.print(`Result: ${result}`);
+                    return result;
+                });
         },
 
         _cmdUpdateAppList: function() {
@@ -336,7 +359,7 @@ odoo.define("terminal.functions.Common", function(require) {
                     this.screen.printError("The given tour doesn't exists!");
                 } else {
                     odoo.__DEBUG__.services["web_tour.tour"].run(tour_name);
-                    this.print("Running tour...");
+                    this.screen.print("Running tour...");
                 }
             } else if (tour_names.length) {
                 this.screen.print(tour_names);

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -555,26 +555,7 @@ odoo.define("terminal.functions.Common", function(require) {
                     kwargs: {context: this._getContext()},
                 })
                 .then(result => {
-                    let tbody = "";
-                    const columns = ["id"];
-                    const l = result.length;
-                    for (let x = 0; x < l; ++x) {
-                        const item = result[x];
-                        tbody += "<tr>";
-                        tbody += this._templates.render("TABLE_BODY_CMD", {
-                            id: item.id,
-                            model: model,
-                        });
-                        for (const field in item) {
-                            if (field === "id") {
-                                continue;
-                            }
-                            columns.push(field);
-                            tbody += `<td>${item[field]}</td>`;
-                        }
-                        tbody += "</tr>";
-                    }
-                    this.screen.printTable(_.unique(columns), tbody);
+                    this.screen.printRecords(model, result);
                     return result;
                 });
         },
@@ -906,12 +887,34 @@ odoo.define("terminal.functions.Common", function(require) {
             offset,
             order
         ) {
+            const lines_total = this.screen._max_lines - 3;
             let fields = ["display_name"];
             if (field_names) {
                 fields =
                     field_names === "*"
                         ? false
                         : this._parameterReader.splitAndTrim(field_names, ",");
+            }
+
+            // Workaround: '--more' is a special model name to handle print the rest of the previous call result
+            if (model === "--more") {
+                const buff = this._buffer[this.__meta.name];
+                if (!buff || !buff.data.length) {
+                    this.screen.printError(
+                        "There are no more results to print"
+                    );
+                    return Promise.resolve();
+                }
+                const sresult = buff.data.slice(0, lines_total);
+                buff.data = buff.data.slice(lines_total);
+                this.screen.printRecords(buff.model, sresult);
+                if (buff.data.length) {
+                    this.screen.print(
+                        `There are still results to print (${buff.data.length}). Continue using '<strong class='o_terminal_click o_terminal_cmd' data-cmd='search --more'>--more</strong>'...`
+                    );
+                }
+                this.screen.print(`Records count: ${sresult.length}`);
+                return Promise.resolve(sresult);
             }
 
             return rpc
@@ -926,27 +929,25 @@ odoo.define("terminal.functions.Common", function(require) {
                     kwargs: {context: this._getContext()},
                 })
                 .then(result => {
-                    let tbody = "";
-                    const columns = ["id"];
-                    const len = result.length;
-                    for (let x = 0; x < len; ++x) {
-                        const item = result[x];
-                        tbody += "<tr>";
-                        tbody += this._templates.render("TABLE_SEARCH_ID", {
-                            id: item.id,
+                    const need_truncate =
+                        !this._mute_mode && result.length > lines_total;
+                    let sresult = result;
+                    if (need_truncate) {
+                        this._buffer[this.__meta.name] = {
                             model: model,
-                        });
-                        for (const field in item) {
-                            if (field === "id") {
-                                continue;
-                            }
-                            columns.push(field);
-                            tbody += `<td>${item[field]}</td>`;
-                        }
-                        tbody += "</tr>";
+                            data: sresult.slice(lines_total),
+                        };
+                        sresult = sresult.slice(0, lines_total);
                     }
-                    this.screen.printTable(_.unique(columns), tbody);
-                    this.screen.print(`Records count: ${len}`);
+                    this.screen.printRecords(model, sresult);
+                    if (need_truncate) {
+                        this.screen.printError(
+                            `<strong class='text-warning'>Result truncated!</strong> The query is too big to be displayed entirely. Use '<strong class='o_terminal_click o_terminal_cmd' data-cmd='search --more'>search --more</strong>' to print the rest of the results (${
+                                this._buffer[this.__meta.name].data.length
+                            })...`
+                        );
+                    }
+                    this.screen.print(`Records count: ${sresult.length}`);
                     return result;
                 });
         },

--- a/odoo/js/functions/core.js
+++ b/odoo/js/functions/core.js
@@ -32,7 +32,6 @@ odoo.define("terminal.functions.Core", function(require) {
                 detail: "Eval parameters and print the result.",
                 syntaxis: "<STRING: MSG>",
                 args: "",
-                sanitized: false,
             });
             this.registerCommand("load", {
                 definition: "Load external resource",

--- a/odoo/js/functions/fuzz.js
+++ b/odoo/js/functions/fuzz.js
@@ -1,4 +1,5 @@
-// Copyright 2018-2020 Alexandre Díaz <dev@redneboa.es>
+/* global py */
+// Copyright 2020 Alexandre Díaz <dev@redneboa.es>
 // License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 /*
@@ -13,6 +14,7 @@ odoo.define("terminal.functions.Fuzz", function(require) {
     const Class = require("web.Class");
     const rpc = require("web.rpc");
     const field_utils = require("web.field_utils");
+    const utils = require("web.utils");
 
     const FieldValueGenerator = Class.extend({
         _minStr: 4,
@@ -30,9 +32,10 @@ odoo.define("terminal.functions.Fuzz", function(require) {
                 datetime: this._generateDatetimeValue.bind(this),
                 selection: this._generateSelectionValue.bind(this),
                 many2one: this._generateMany2OneValue.bind(this),
-                // One2many: this._generateOne2ManyValue.bind(this),
+                one2many: this._generateOne2ManyValue.bind(this),
                 many2many: this._generateMany2ManyValue.bind(this),
                 boolean: this._generateBooleanValue.bind(this),
+                monetary: this._generateFloatValue.bind(this),
 
                 phone: this._generatePhoneValue.bind(this),
                 email: this._generateEmailValue.bind(this),
@@ -41,13 +44,13 @@ odoo.define("terminal.functions.Fuzz", function(require) {
             this._parameterGenerator = new ParameterGenerator();
         },
 
-        process: function(field) {
+        process: function(field, omitted_values) {
             const hasWidgetGenerator = field.widget in this._generators;
             const callback = this._generators[
                 hasWidgetGenerator ? field.widget : field.type
             ];
             if (callback) {
-                return callback(field);
+                return callback(field, omitted_values);
             }
             return false;
         },
@@ -68,11 +71,9 @@ odoo.define("terminal.functions.Fuzz", function(require) {
         },
 
         _generateFloatValue: function() {
-            return Number(
-                this._parameterGenerator.generateInt(
-                    this._minNumber,
-                    this._maxNumber
-                )
+            return this._parameterGenerator.generateFloat(
+                this._minNumber,
+                this._maxNumber
             );
         },
 
@@ -98,44 +99,48 @@ odoo.define("terminal.functions.Fuzz", function(require) {
         },
 
         _generateSelectionValue: function(field) {
-            const index = this._parameterGenerator.generateInt(
-                0,
-                field.values.length - 1
-            );
-            return field.values[index];
+            return _.sample(field.values);
         },
 
-        _generateOne2ManyValue: function() {
-            // TODO: CREATE NEW RECORDS FOR THIS TYPE OF FIELD
-            // {
-            //     operation: 'CREATE',
-            //     data: values,
-            // },
+        _generateOne2ManyValue: function(field) {
+            const keys = Object.keys(field.values);
+            if (!keys.length) {
+                return false;
+            }
+            const record = {};
+            for (const key of keys) {
+                const extra_field = field.values[key];
+                record[key] = this.process(extra_field);
+            }
+            return {
+                operation: "CREATE",
+                data: record,
+            };
+        },
+
+        _generateMany2OneValue: function(field, omitted_values) {
+            const value = _.sample(
+                _.difference(field.values, omitted_values || [])
+            );
+            if (value) {
+                return {operation: "ADD", id: value};
+            }
             return false;
         },
 
-        _generateMany2OneValue: function(field) {
-            const index = this._parameterGenerator.generateInt(
-                0,
-                field.values.length - 1
-            );
-            return {operation: "ADD", id: field.values[index]};
-        },
-
         _generateMany2ManyValue: function(field) {
-            const end = this._parameterGenerator.generateInt(
+            const num = this._parameterGenerator.generateInt(
                 0,
                 field.values.length - 1
             );
-            const start = this._parameterGenerator.generateInt(
-                field.values.length - end,
-                field.values.length - 1
-            );
-            const ids = field.values.slice(start, start + end);
-            return {
-                operation: "ADD_M2M",
-                ids: _.map(ids, id => Object({id: id})),
-            };
+            const ids = _.sample(field.values, num);
+            if (ids.length) {
+                return {
+                    operation: "ADD_M2M",
+                    ids: _.map(ids, id => Object({id: id})),
+                };
+            }
+            return false;
         },
 
         _generateBooleanValue: function() {
@@ -164,11 +169,392 @@ odoo.define("terminal.functions.Fuzz", function(require) {
         },
     });
 
+    const FuzzDialogForm = Class.extend({
+        init: function(term) {
+            this._term = term;
+            this._fieldValueGenerator = new FieldValueGenerator();
+        },
+
+        destroy: function() {
+            this._fieldValueGenerator.destroy();
+        },
+
+        processFormFields: function(controller) {
+            return new Promise(async resolve => {
+                const controller_state = controller.widget.renderer.state;
+                const fields = controller_state.fields;
+                const fields_info =
+                    controller_state.fieldsInfo[controller_state.viewType];
+                const processed = {};
+                const ignored = [];
+                let fields_ignored = [];
+                const fields_view = this._getArchFields(
+                    controller.widget.renderer.arch
+                );
+                for (const field_view_def of fields_view) {
+                    const field_name = field_view_def.attrs.name;
+                    if (fields_ignored.indexOf(field_name) !== -1) {
+                        this._term.screen.eprint(
+                            ` [i] Aborting changes for '${field_name}': Already changed by an 'onchange'`
+                        );
+                        ignored.push(field_name);
+                        continue;
+                    }
+                    const field_info = fields_info[field_name];
+                    const field = fields[field_name];
+                    const is_invisible = utils.toBoolElse(
+                        field_info.modifiersValue?.invisible
+                    );
+                    const is_readonly = utils.toBoolElse(
+                        field_info.modifiersValue?.readonly,
+                        field.readonly
+                    );
+                    if (!is_invisible && !is_readonly) {
+                        // Create more than one 'one2many' record
+                        const num_records =
+                            field.type === "one2many"
+                                ? this._fieldValueGenerator._parameterGenerator.generateInt(
+                                      7
+                                  )
+                                : 1;
+                        this._O2MRequiredStore = {};
+                        for (let i = 0; i < num_records; ++i) {
+                            const [
+                                field_def,
+                                affected_fields,
+                            ] = await this._fillField(
+                                controller,
+                                field,
+                                field_info
+                            );
+                            processed[field_name] = field_def;
+                            fields_ignored = _.union(
+                                fields_ignored,
+                                affected_fields
+                            );
+                        }
+                    }
+                }
+                return resolve([processed, ignored]);
+            });
+        },
+
+        _convertData2State: function(data) {
+            const res = {};
+            for (const key in data) {
+                const value = data[key];
+                if (typeof value === "object" && !moment.isMoment(value)) {
+                    res[key] = value.data?.id;
+                } else {
+                    res[key] = value;
+                }
+            }
+            return res;
+        },
+
+        _fillField: function(controller, field, field_info) {
+            return new Promise(async resolve => {
+                const local_data =
+                    controller.widget.model.localData[controller.widget.handle];
+                const domain = controller.widget.model._getDomain(local_data, {
+                    fieldName: field_info.name,
+                });
+                const state_data = controller.widget.renderer.state.data;
+                this._term.screen.eprint(
+                    ` [o] Getting information of '${field_info.name}' field...`
+                );
+
+                let changes = {};
+                let gen_field_def = {};
+                // One2many fields need be handled in a special way
+                if (field.type === "one2many") {
+                    gen_field_def = await this._generateFieldDef(
+                        field,
+                        field_info,
+                        domain
+                    );
+                    changes = await this._generateChangesFieldO2M(
+                        field_info,
+                        controller.widget
+                    );
+                } else {
+                    gen_field_def = await this._generateFieldDef(
+                        field,
+                        field_info,
+                        domain
+                    );
+                    changes[
+                        field_info.name
+                    ] = this._fieldValueGenerator.process(gen_field_def);
+                }
+                // Get the raw value to human printing
+                let raw_value = changes[field_info.name];
+                if (typeof raw_value === "object" && "operation" in raw_value) {
+                    if (raw_value.operation === "ADD") {
+                        raw_value = raw_value.id;
+                    } else if (raw_value.operation === "ADD_M2M") {
+                        raw_value = _.map(
+                            raw_value.ids,
+                            item => item.id
+                        ).join();
+                    } else if (raw_value.operation === "CREATE") {
+                        raw_value = raw_value.data;
+                    }
+                }
+                if (typeof raw_value === "object") {
+                    this._term.screen.eprint(
+                        " [o] Writing the new random value:"
+                    );
+                    this._term.screen.print(
+                        this._term.screen._prettyObjectString(raw_value)
+                    );
+                } else {
+                    this._term.screen.eprint(
+                        ` [o] Writing the new random value: ${raw_value}`
+                    );
+                }
+                try {
+                    const record_id = controller.widget.handle;
+                    const model = controller.widget.model;
+                    await model.trigger_up("field_changed", {
+                        dataPointID: record_id,
+                        changes: changes,
+                        onSuccess: datas => {
+                            const fields_affected = _.reject(
+                                this._processFieldChanges(
+                                    field_info.name,
+                                    datas,
+                                    state_data
+                                ),
+                                item => item === field_info.name
+                            );
+                            this._term.screen.eprint(
+                                ` [i] Random value for '${field_info.name}' written`
+                            );
+                            if (_.some(fields_affected)) {
+                                this._term.screen.eprint(
+                                    `  ** 'onchange' fields detected: ${fields_affected.join()}`
+                                );
+                            }
+                            return resolve([gen_field_def, fields_affected]);
+                        },
+                    });
+                } catch (err) {
+                    this._term.screen.eprint(
+                        ` [x] Can't write the value for '${field_info.name}': ${err}`
+                    );
+                }
+            });
+        },
+
+        _getArchFields: function(arch) {
+            let fields = [];
+            for (const children of arch.children) {
+                if (children.tag === "field") {
+                    fields.push(children);
+                } else if (_.some(children.children)) {
+                    fields = _.union(fields, this._getArchFields(children));
+                }
+            }
+            return fields;
+        },
+
+        _getChangesValues: function(changes) {
+            const values = {};
+            for (const field_name in changes) {
+                const change = changes[field_name];
+                if (typeof change === "object" && "operation" in change) {
+                    if (change.operation === "ADD") {
+                        values[field_name] = change.id;
+                    } else if (change.operation === "ADD_M2M") {
+                        values[field_name] = _.map(change.ids, item => item.id);
+                    } else if (change.operation === "CREATE") {
+                        values[field_name] = change.data;
+                    }
+                } else {
+                    values[field_name] = change;
+                }
+            }
+            return values;
+        },
+
+        _processO2MRequiredField: function(
+            parent_field_name,
+            field_name,
+            field_view,
+            changes
+        ) {
+            if (field_view.required) {
+                const s_changes = this._getChangesValues(
+                    changes[parent_field_name].data
+                );
+                if (!(parent_field_name in this._O2MRequiredStore)) {
+                    this._O2MRequiredStore[parent_field_name] = {};
+                }
+                if (
+                    !(field_name in this._O2MRequiredStore[parent_field_name])
+                ) {
+                    this._O2MRequiredStore[parent_field_name][field_name] = [];
+                }
+                this._O2MRequiredStore[parent_field_name][field_name].push(
+                    s_changes[field_name]
+                );
+            }
+        },
+
+        _generateChangesFieldO2M: async function(field_info, widget) {
+            return new Promise(async resolve => {
+                const changes = {};
+                changes[field_info.name] = {
+                    operation: "CREATE",
+                    data: {},
+                };
+                if (field_info.views) {
+                    const o2m_fields = this._getArchFields(
+                        field_info.views[field_info.mode]?.arch
+                    );
+                    for (const index in o2m_fields) {
+                        const field = o2m_fields[index];
+                        const field_view_name = field.attrs.name;
+                        const field_view_def =
+                            field_info.views[field_info.mode].fields[
+                                field_view_name
+                            ];
+                        const field_view =
+                            field_info.views[field_info.mode].fields[
+                                field_view_name
+                            ];
+                        const field_info_view =
+                            field_info.views[field_info.mode].fieldsInfo[
+                                field_info.mode
+                            ][field_view_name];
+                        if (!field_info_view) {
+                            continue;
+                        }
+                        const is_invisible = utils.toBoolElse(
+                            field_info_view.modifiers?.invisible,
+                            false
+                        );
+                        if (
+                            field_view.type === "one2many" ||
+                            is_invisible ||
+                            field_view_def.readonly ||
+                            field_view_name.startsWith("_") ||
+                            field_view_name === "id"
+                        ) {
+                            continue;
+                        }
+
+                        const model_data = widget.model.get(widget.handle);
+                        const state = this._convertData2State(model_data.data);
+                        const proc_domain =
+                            (field.attrs.domain &&
+                                py.eval(
+                                    field.attrs.domain,
+                                    _.extend(
+                                        {
+                                            parent: state,
+                                        },
+                                        this._getChangesValues(
+                                            changes[field_info.name].data
+                                        )
+                                    )
+                                )) ||
+                            [];
+                        const gen_field_def = await this._generateFieldDef(
+                            field_view,
+                            field_info_view,
+                            proc_domain
+                        );
+                        let omitted_values = null;
+                        if (field_info.name in this._O2MRequiredStore) {
+                            omitted_values = this._O2MRequiredStore[
+                                field_info.name
+                            ][field_view_name];
+                        }
+                        const data = this._fieldValueGenerator.process(
+                            gen_field_def,
+                            omitted_values
+                        );
+                        if (data) {
+                            changes[field_info.name].data[
+                                field_view_name
+                            ] = data;
+                            this._processO2MRequiredField(
+                                field_info.name,
+                                field_view_name,
+                                field_view,
+                                changes
+                            );
+                        } else {
+                            changes[field_info.name].data = [];
+                            break;
+                        }
+                    }
+                }
+                // Do not apply changes if doesn't exists changes to apply
+                if (!Object.keys(changes[field_info.name].data).length) {
+                    changes[field_info.name] = false;
+                }
+                return resolve(changes);
+            });
+        },
+
+        _generateFieldDef: function(field, field_info = false, domain = []) {
+            return new Promise(async resolve => {
+                const gen_field_def = {
+                    type: field.type,
+                    relation: field.relation,
+                    widget: "",
+                    required: field.required,
+                };
+                if (field_info) {
+                    gen_field_def.widget = field_info.widget;
+                    gen_field_def.required =
+                        field_info.modifiersValue?.required;
+                }
+
+                if (gen_field_def.relation) {
+                    gen_field_def.values = await rpc.query({
+                        model: gen_field_def.relation,
+                        method: "search",
+                        args: [domain],
+                    });
+                } else if (field.selection) {
+                    gen_field_def.values = [];
+                    for (const option of field.selection) {
+                        gen_field_def.values.push(option[0]);
+                    }
+                }
+
+                return resolve(gen_field_def);
+            });
+        },
+
+        _processFieldChanges: function(field_name, datas, state_data) {
+            const fields_changed = [];
+            for (const data of datas) {
+                if (data.name === field_name) {
+                    for (const rf_name in data.recordData) {
+                        if (
+                            !_.isEqual(
+                                data.recordData[rf_name],
+                                state_data[rf_name]
+                            )
+                        ) {
+                            fields_changed.push(rf_name);
+                        }
+                    }
+                    break;
+                }
+            }
+            return fields_changed;
+        },
+    });
+
     Terminal.include({
         init: function() {
             this._super.apply(this, arguments);
-
-            this._fieldValueGenerator = new FieldValueGenerator();
 
             this.registerCommand("fuzz", {
                 definition: "Run a 'Fuzz Test'",
@@ -198,10 +584,11 @@ odoo.define("terminal.functions.Fuzz", function(require) {
                 const form_controller = this._getController(
                     action.controllerID
                 );
+                const fuzz_dialog_form = new FuzzDialogForm(this);
                 const [
                     processed_fields,
                     ignored_fields,
-                ] = await this._processFormFields(form_controller);
+                ] = await fuzz_dialog_form.processFormFields(form_controller);
                 const required_count = _.size(
                     _.filter(processed_fields, field => field.required)
                 );
@@ -239,170 +626,6 @@ odoo.define("terminal.functions.Fuzz", function(require) {
 
         _getController: function(controller_id) {
             return this.getParent().action_manager.controllers[controller_id];
-        },
-
-        _processFormFields: function(controller) {
-            return new Promise(async resolve => {
-                const fields = controller.widget.renderer.state.fields;
-                const fields_info =
-                    controller.widget.renderer.state.fieldsInfo.form;
-                const model = controller.widget.model;
-                const record_id = controller.widget.handle;
-                const processed = {};
-                const ignored = [];
-                let fields_ignored = [];
-                for (const field_name in fields_info) {
-                    if (fields_ignored.indexOf(field_name) !== -1) {
-                        this.screen.eprint(
-                            ` [i] Aborting changes for '${field_name}': Already changed by an 'onchange'`
-                        );
-                        ignored.push(field_name);
-                        continue;
-                    }
-                    const field_info = fields_info[field_name];
-                    const field = fields[field_name];
-                    const $input = controller.dialog.$(
-                        `input[name='${field_info.name}']:not(.o_invisible_modifier),div[name='${field_info.name}']:not(.o_invisible_modifier) input,select[name='${field_info.name}']:not(.o_invisible_modifier),textarea[name='${field_info.name}']:not(.o_invisible_modifier)`
-                    );
-                    if (
-                        $input.length &&
-                        !$input.parent().hasClass("o_invisible_modifier")
-                    ) {
-                        const local_data =
-                            controller.widget.model.localData[
-                                controller.widget.handle
-                            ];
-                        const domain = controller.widget.model._getDomain(
-                            local_data,
-                            {fieldName: field_info.name}
-                        );
-                        const state_data =
-                            controller.widget.renderer.state.data;
-                        const [
-                            field_def,
-                            affected_fields,
-                        ] = await this._fillField(
-                            $input,
-                            record_id,
-                            model,
-                            domain,
-                            field,
-                            field_info,
-                            state_data
-                        );
-                        processed[field_name] = field_def;
-                        fields_ignored = _.union(
-                            fields_ignored,
-                            affected_fields
-                        );
-                    }
-                }
-                return resolve([processed, ignored]);
-            });
-        },
-
-        _fillField: function(
-            $input,
-            record_id,
-            model,
-            domain,
-            field,
-            field_info,
-            state_data
-        ) {
-            return new Promise(async resolve => {
-                this.screen.eprint(
-                    ` [o] Getting information of '${field_info.name}' field...`
-                );
-                const gen_field_def = {
-                    $input: $input,
-                    type: field.type,
-                    relation: field.relation,
-                    widget: field_info.widget,
-                    required: field_info.modifiersValue?.required,
-                };
-                if (gen_field_def.relation) {
-                    gen_field_def.values = await rpc.query({
-                        model: gen_field_def.relation,
-                        method: "search",
-                        args: [domain],
-                    });
-                } else if (field.selection) {
-                    gen_field_def.values = [];
-                    for (const option of field.selection) {
-                        gen_field_def.values.push(option[0]);
-                    }
-                }
-
-                const changes = {};
-                changes[field_info.name] = this._fieldValueGenerator.process(
-                    gen_field_def
-                );
-                // Get the raw value to human printing
-                let raw_value = changes[field_info.name];
-                if (typeof raw_value === "object" && "operation" in raw_value) {
-                    if (raw_value.operation === "ADD") {
-                        raw_value = raw_value.id;
-                    } else if (raw_value.operation === "ADD_M2M") {
-                        raw_value = _.map(
-                            raw_value.ids,
-                            item => item.id
-                        ).join();
-                    }
-                }
-                this.screen.eprint(
-                    ` [o] Writing the new random value: ${raw_value}`
-                );
-                try {
-                    await model.trigger_up("field_changed", {
-                        dataPointID: record_id,
-                        changes: changes,
-                        onSuccess: datas => {
-                            const fields_affected = _.reject(
-                                this._processFieldChanges(
-                                    field_info.name,
-                                    datas,
-                                    state_data
-                                ),
-                                item => item === field_info.name
-                            );
-                            this.screen.eprint(
-                                ` [i] Random value for '${field_info.name}' written`
-                            );
-                            if (_.some(fields_affected)) {
-                                this.screen.eprint(
-                                    `  ** 'onchange' fields detected: ${fields_affected.join()}`
-                                );
-                            }
-                            return resolve([gen_field_def, fields_affected]);
-                        },
-                    });
-                } catch (err) {
-                    this.screen.eprint(
-                        ` [x] Can't write the value for '${field_info.name}': ${err}`
-                    );
-                }
-            });
-        },
-
-        _processFieldChanges: function(field_name, datas, state_data) {
-            const fields_changed = [];
-            for (const data of datas) {
-                if (data.name === field_name) {
-                    for (const rf_name in data.recordData) {
-                        if (
-                            !_.isEqual(
-                                data.recordData[rf_name],
-                                state_data[rf_name]
-                            )
-                        ) {
-                            fields_changed.push(rf_name);
-                        }
-                    }
-                    break;
-                }
-            }
-            return fields_changed;
         },
     });
 });


### PR DESCRIPTION
IMP: Command 'caf': Sorted by field name
IMP: Screen: Use less nodes
IMP: Screen: Auto vacuum (No more than 750 lines)
IMP: Command 'repeat': Try to be nice with the main thread
IMP: Command 'fuzz': Support one2many fields and other improvements
IMP: ParameterReader: Now can use slashes to avoid double quotes grouping (Example: "This \"is\" an example")
IMP: Handle big results: split current query to not block/crash the browser

ADD: Command 'mute': Runs the command only printing errors. (Useful with the 'repeat' command)
ADD: Command 'count': Get the number of records
ADD: Command 'exportfile': Exports the command result to a text file
ADD: New parameter generator: $FLOAT
ADD: Prompt changes the color per host (locahost doesn't have any color)

FIX: Changed some calls using the old 'print' call
FIX: Command 'caf': Now can use 'fields' parameter
FIX: Shadow Input: Correct sync. with input scroll left