### PR TITLE
Working on v8.0.0...

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,6 @@
 env:
   browser: true
+  es6: true
 
 parserOptions:
   ecmaVersion: 2020
@@ -12,10 +13,8 @@ globals:
   jQuery: readonly
   moment: readonly
   odoo: readonly
+  py: readonly
   openerp: off
-  Promise: readonly
-  Symbol: readonly
-  BigInt: readonly
 
 # Styling is handled by Prettier, so we only need to enable AST rules;
 # see https://github.com/OCA/maintainer-quality-tools/pull/618#issuecomment-558576890
@@ -33,7 +32,9 @@ rules:
     - 13
   constructor-super: warn
   dot-notation: warn
-  eqeqeq: warn
+  eqeqeq:
+    - error
+    - smart
   global-require: warn
   handle-callback-err: warn
   id-blacklist: warn
@@ -64,7 +65,6 @@ rules:
   no-empty-function: error
   no-empty-pattern: error
   no-empty: warn
-  no-eq-null: error
   no-eval: error
   no-ex-assign: error
   no-extend-native: warn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.3.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.17.0
+    rev: v7.32.0
     hooks:
       - id: eslint
         verbose: true
@@ -14,7 +14,7 @@ repos:
           - --color
           - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMP: Parameter reader: support json parameter
 IMP: Command 'caf': hightlight required fields
 IMP: Command 'help': More verbose format
 IMP: Command 'login': Now uses '#' instead of '-'
+IMP: Command 'repeat': New argument '--silent'
 IMP: Support with "master" branch (pre 15.0)
 IMP: ParamaterReader: Now supports 'named arguments'
 IMP: Command definition: Rework 'args' and removed unused properties (syntax)
@@ -16,6 +17,8 @@ ADD: Command 'lang': Operations over translations (issue #30)
 ADD: 'delete' option to 'context' and 'context_term' commands
 
 FIX: Disable 'native autocomplete' in chrome
+
+DEL: Command 'mute'. Now is part of the execution implementation
 ```
 
 **7.3.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@
 ```
 IMP: Screen: reflows
 IMP: Parameter reader: support json parameter
-IMP: Command 'caf': hightlight required fields
+IMP: Command 'caf': hightlight required fields and new argument to apply a filter
 IMP: Command 'help': More verbose format
 IMP: Command 'login': Now uses '#' instead of '-'
 IMP: Command 'repeat': New argument '--silent'
 IMP: Support with "master" branch (pre 15.0)
 IMP: ParamaterReader: Now supports 'named arguments'
 IMP: Command definition: Rework 'args' and removed unused properties (syntax)
+IMP: Shadow input: preview: Show possible parameter
 
 ADD: Command 'lang': Operations over translations (issue #30)
 ADD: 'delete' option to 'context' and 'context_term' commands
+ADD: Command Assistant
 
 FIX: Disable 'native autocomplete' in chrome
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 **8.0.0**
 
 ```
-IMP: Now terminal is always on top
-IMP: Reflows
-IMP: Parameter reader
+IMP: Screen: reflows
+IMP: Parameter reader: support json parameter
+IMP: Command 'caf': hightlight required fields
+IMP: Support with "master" branch (pre 15.0)
 
 ADD: Command 'pot': Operations over translations (issue #30)
 ADD: 'delete' option to context and context_term commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@
 IMP: Screen: reflows
 IMP: Parameter reader: support json parameter
 IMP: Command 'caf': hightlight required fields
+IMP: Command 'help': More verbose format
+IMP: Command 'login': Now uses '#' instead of '-'
 IMP: Support with "master" branch (pre 15.0)
+IMP: ParamaterReader: Now supports 'named arguments'
+IMP: Command definition: Rework 'args' and removed unused properties (syntax)
 
-ADD: Command 'pot': Operations over translations (issue #30)
-ADD: 'delete' option to context and context_term commands
+ADD: Command 'lang': Operations over translations (issue #30)
+ADD: 'delete' option to 'context' and 'context_term' commands
 
-FIX: Syntax typo (pr #28)
-FIX: Disable 'autocomplete' in chrome
+FIX: Disable 'native autocomplete' in chrome
 ```
 
 **7.3.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+**8.0.0**
+
+```
+IMP: Now terminal is always on top
+IMP: Reflows
+IMP: Parameter reader
+
+ADD: Command 'pot': Operations over translations (issue #30)
+ADD: 'delete' option to context and context_term commands
+
+FIX: Syntax typo (pr #28)
+FIX: Disable 'autocomplete' in chrome
+```
+
 **7.3.0**
 
 ```

--- a/README.md
+++ b/README.md
@@ -47,22 +47,28 @@ You can toggle terminal using one of these options:
 
 ## Example Commands
 
-| Description                                         | Terminal Command                                   |
-| --------------------------------------------------- | -------------------------------------------------- |
-| Create 'res.partner' record                         | `create res.partner "{'name': 'The One'}"`         |
-| Search 'res.partner' records                        | `search res.partner name,email "[['id', '>', 5]]"` |
-| Search all fields of selected 'res.partner' records | `search res.partner * "[['id', '>', 5]]"`          |
-| Read all fields of selected 'res.partner' record    | `read res.partner 5 *`                             |
-| Read all fields of various 'res.partner' records    | `read res.partner 5,15,8 *`                        |
-| View 'res.partner' records _(only backend)_         | `view res.partner`                                 |
-| View selected 'res.partner' record _(only backend)_ | `view res.partner 4`                               |
-| Install module                                      | `install mymodule`                                 |
-| Create alias                                        | `alias myalias print My name is $1`                |
+| Description                                         | Terminal Command                                                            |
+| --------------------------------------------------- | --------------------------------------------------------------------------- |
+| Create 'res.partner' record                         | `create -m res.partner -v "{'name': 'Hipcut', 'street': 'Mystery street'}"` |
+| Search 'res.partner' records                        | `search -m res.partner -f name,email -d "[['id', '>', 5]]"`                 |
+| Search all fields of selected 'res.partner' records | `search -m res.partner -f * -d "[['id', '>', 5]]"`                          |
+| Read all fields of selected 'res.partner' record    | `read -m res.partner -i 5 -f *`                                             |
+| Read all fields of various 'res.partner' records    | `read -m res.partner -i 5,15,8 -f *`                                        |
+| View 'res.partner' records _(only backend)_         | `view -m res.partner`                                                       |
+| View selected 'res.partner' record _(only backend)_ | `view -m res.partner -i 4`                                                  |
+| Install module                                      | `install -m mymodule`                                                       |
+| Create alias                                        | `alias -n myalias -c "print My name is $1"`                                 |
 
 > Notice the usage of quotes when use parameters with spaces.
 
 > Notice that a list is an string of values separated by commas. Example: "5,
 > 15, 8"
+
+> Notice that can call commands without 'named arguments', for example:
+> `create res.partner "{'name': 'Hipcut', 'street': 'Mystery street'}"` The rule
+> is that 'unnamed arguments' fill values following the order of the command
+> arguments definition. So mix 'unnamed' with 'named' arguments can be done as
+> long as the order is maintained.
 
 ## Notes
 
@@ -111,8 +117,8 @@ The anatomy of a generator is: `$type[min,max]`, `$type[max]` or `$type`
 For example:
 
 - create a new record with a random string:
-  `create res.partner "{'name': '$STR[4,30]'}"`
-- print the current time: `print $NOWTIME`
+  `create -m res.partner -v "{'name': '$STR[4,30]'}"`
+- print the current time: `print -m $NOWTIME`
 
 > Notice that 'date' min and max are the milliseconds since 1970/01/01
 
@@ -126,11 +132,11 @@ The anatomy of a positional replacement is: `$num[default_value]` or `$num`
 For example:
 
 - First positional replacement (without default value = empty):
-  `alias my_alias print Hello, $1`
+  `alias -n my_alias -c "print Hello, $1"`
 - Fist position replacement with default value 'world':
-  `alias my_alias print Hello, $1[world]`
+  `alias -n my_alias -c "print Hello, $1[world]"`
 - A somewhat more complex:
-  `alias search_mod search ir.module.module display_name "[['name', '=', '$1'], ['state', '=', '$2[installed]']]"`
+  `alias -n search_mod -c "search ir.module.module display_name \"[['name', '=', '$1'], ['state', '=', '$2[installed]']]\""`
 
 #### + Runners (subcommands)
 
@@ -138,14 +144,15 @@ You can execute "subcommands" to use the result in a new command call. The
 syntax of runners looks like `{{command}}`, `{{command}}.key` or
 `{{command}}[index]`.
 
-For example: `read res.users {{search res.users id []}}.id`
+For example: `read -m res.users -i {{search res.users id []}}.id`
 
 #### + Massive operations
 
 Massive operations are possible using the command `repeat`. Print to screen is a
 expensive task, consider use the command `mute` to increase the performance.
 
-Example: `repeat 5000 mute create res.partner "{'name': '$STR[12] (Test)'}"`
+Example:
+`repeat -t 5000 -c "mute -c \"create res.partner \"{'name': '$STR[12] (Test)'}\"\""`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ The anatomy of a positional replacement is: `$num[default_value]` or `$num`
 For example:
 
 - First positional replacement (without default value = empty):
-  `alias -n my_alias -c "print Hello, $1"`
+  `alias -n my_alias -c "print -m 'Hello, $1'"`
 - Fist position replacement with default value 'world':
-  `alias -n my_alias -c "print Hello, $1[world]"`
+  `alias -n my_alias -c "print -m 'Hello, $1[world]'"`
 - A somewhat more complex:
-  `alias -n search_mod -c "search ir.module.module display_name \"[['name', '=', '$1'], ['state', '=', '$2[installed]']]\""`
+  `alias -n search_mod -c "search -m ir.module.module -f display_name -d '[[\"name\", \"=\", \"$1\"], [\"state\", \"=\", \"$2[installed]\"]]'"`
 
 #### + Runners (subcommands)
 
@@ -144,15 +144,16 @@ You can execute "subcommands" to use the result in a new command call. The
 syntax of runners looks like `{{command}}`, `{{command}}.key` or
 `{{command}}[index]`.
 
-For example: `read -m res.users -i {{search res.users id []}}.id`
+For example: `read -m res.users -i {{search -m res.users -f id}}.id`
 
 #### + Massive operations
 
 Massive operations are possible using the command `repeat`. Print to screen is a
-expensive task, consider use the command `mute` to increase the performance.
+expensive task, consider use the `--slient` argument to increase the
+performance.
 
 Example:
-`repeat -t 5000 -c "mute -c \"create res.partner \"{'name': '$STR[12] (Test)'}\"\""`
+`repeat -t 5000 -c "create -m res.partner -v '{\"name\": \"$STR[12] (Test)\"}'" --silent`
 
 ---
 

--- a/content_script.js
+++ b/content_script.js
@@ -108,6 +108,7 @@
                 "odoo/js/core/abstract/screen.js",
                 "odoo/js/core/storage.js",
                 "odoo/js/core/template_manager.js",
+                "odoo/js/core/command_assistant.js",
                 "odoo/js/core/screen.js",
                 "odoo/js/core/longpolling.js",
                 "odoo/js/core/parameter_reader.js",

--- a/content_script.js
+++ b/content_script.js
@@ -20,10 +20,13 @@
     const gOdooInfoObj = {
         isOdoo: false,
         isLoaded: false,
-        serverVersion: null,
+        serverVersionRaw: null,
         isCompatible: false,
         isFrontend: false,
-        serverVersionMajor: "12",
+        serverVersion: {
+            major: 12,
+            minor: 0,
+        },
     };
 
     /**
@@ -117,12 +120,22 @@
         // Compatibility resources
         // 11 - v11
         // 12+ - v12
-        const odoo_version = Number(info.serverVersionMajor);
-        if (odoo_version === 11) {
+        // 15+ - v15
+        const odoo_version = info.serverVersion;
+        if (odoo_version.major === 11 && odoo_version.minor === 0) {
             to_inject.js.push("odoo/js/core/compat/v11/common.js");
         }
-        if (odoo_version >= 12) {
+        if (
+            (odoo_version.major === 11 && odoo_version.minor > 0) ||
+            odoo_version.major >= 12
+        ) {
             to_inject.js.push("odoo/js/core/compat/v12/common.js");
+        }
+        if (
+            (odoo_version.major === 14 && odoo_version.minor > 0) ||
+            odoo_version.major >= 15
+        ) {
+            to_inject.js.push("odoo/js/core/compat/v15/common.js");
         }
         // Backend/Frontend resources
         if (info.isFrontend) {

--- a/content_script.js
+++ b/content_script.js
@@ -137,6 +137,17 @@
         return to_inject;
     }
 
+    function getStorageSync(key) {
+        return new Promise((resolve, reject) => {
+            gBrowserObj.storage.sync.get(key, (items) => {
+                if (gBrowserObj.runtime?.lastError) {
+                    return reject(gBrowserObj.runtime.lastError);
+                }
+                resolve(items);
+            });
+        });
+    }
+
     // Listen messages from page script
     window.addEventListener(
         "message",
@@ -159,12 +170,13 @@
                 }
             } else if (event.data.type === "ODOO_TERM_START") {
                 // Load Init Commands
-                gBrowserObj.storage.sync.get(["init_cmds"], (result) => {
-                    const cmds = (result.init_cmds || "").split(/\n\r?/);
+                getStorageSync(["init_cmds"]).then((items) => {
+                    const cmds = (items.init_cmds || "").split(/\n\r?/);
                     window.postMessage(
                         {
-                            type: "ODOO_TERM_EXEC_INIT_CMDS",
-                            cmds: cmds,
+                            type: "ODOO_TERM_CONFIG",
+                            init_cmds: cmds,
+                            user_lang: items.lang,
                         },
                         "*"
                     );

--- a/docs/example_funcs.js
+++ b/docs/example_funcs.js
@@ -14,8 +14,7 @@ odoo.define("terminal.MyFuncs", function (require) {
                 definition: "This is my command",
                 function: this._cmdMyFunc,
                 detail: "My command explained...",
-                syntax:
-                    "<STRING: ParamA> <INT: ParamB> [STRING: ParamC] [INT: ParamD]",
+                syntax: "<STRING: ParamA> <INT: ParamB> [STRING: ParamC] [INT: ParamD]",
                 args: "si?si",
             });
 

--- a/docs/example_funcs.js
+++ b/docs/example_funcs.js
@@ -14,45 +14,43 @@ odoo.define("terminal.MyFuncs", function (require) {
                 definition: "This is my command",
                 function: this._cmdMyFunc,
                 detail: "My command explained...",
-                syntax: "<STRING: ParamA> <INT: ParamB> [STRING: ParamC] [INT: ParamD]",
-                args: "si?si",
+                args: [
+                    "s::pa:parama::1::The Param A",
+                    "i::pb:paramb::1::The Param B",
+                    "s::pc:paramc::0::The Param C::DefaultValue",
+                    "i::pd:paramd::0::The Param D::-1",
+                ],
             });
 
             this.registerCommand("myasynccommand", {
                 definition: "This is my async command",
                 function: this._cmdMyAsyncFunc,
                 detail: "My async command explained...",
-                syntax: "<INT: ParamA> <INT: ParamB>",
-                args: "si",
+                args: [
+                    "s::pa:parama::1::The Param A",
+                    "i::pb:paramb::1::The Param B",
+                ],
             });
         },
 
         /**
          * Basic implementation example for the 'mycommand' command
          *
-         * @param {String} param_a
-         * @param {Int} param_b
-         * @param {String} param_c
-         * @param {Int} param_d
+         * @param {Object} kwargs
          * @returns {Promise}
          */
-        _cmdMyFunc: function (
-            param_a,
-            param_b,
-            param_c = "DefaultValue",
-            param_d = -1
-        ) {
+        _cmdMyFunc: function (kwargs) {
             this.screen.print("Hello, World!");
-            this.screen.eprint("ParamA (String): " + param_a);
-            this.screen.eprint("ParamB (Int): " + param_b);
-            this.screen.eprint("ParamC (Optional String): " + param_c);
-            this.screen.eprint("ParamD (Optional Int): " + param_d);
+            this.screen.eprint("ParamA (String): " + kwargs.parama);
+            this.screen.eprint("ParamB (Int): " + kwargs.paramb);
+            this.screen.eprint("ParamC (Optional String): " + kwargs.paramc);
+            this.screen.eprint("ParamD (Optional Int): " + kwargs.paramd);
 
-            if (param_b instanceof Number) {
+            if (kwargs.paramb instanceof Number) {
                 this.screen.print("ParamB is a Number!");
             }
 
-            if (param_a !== param_c) {
+            if (kwargs.parama !== kwargs.paramc) {
                 this.screen.printError(
                     "Invalid! ParamA need be the same as ParamC"
                 );
@@ -68,14 +66,13 @@ odoo.define("terminal.MyFuncs", function (require) {
          * wrapping them. So for this reason you must use 'return' to
          * finalize the awaitable promise and propagate the results.
          *
-         * @param {Int} param_a
-         * @param {Int} param_b
+         * @param {Object} kwargs
          * @returns {Promise}
          */
-        _cmdMyAsyncFunc: function (param_a, param_b) {
+        _cmdMyAsyncFunc: function (kwargs) {
             return new Promise(async (resolve, reject) => {
-                const result = await Promise.resolve(param_a);
-                const other_result = await Promise.resolve(param_b);
+                const result = await Promise.resolve(kwargs.parama);
+                const other_result = await Promise.resolve(kwargs.paramb);
 
                 if (result !== other_result) {
                     return reject("Something is wrong!");

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -40,13 +40,13 @@ Commands uses promises
   - [] Optional
 - args: Command Paramerters Types
   - 's' String
-  - 'i' Integer
+  - 'i' Number
+  - 'j' String. Using JSON.parse
   - '?' Indicates that next parameters are optional
   - '\*' All the rest (unknown) of params are formatted as string
   - 'l' Indicates that the next parameter can be a list (a list is a string of
     values separted by commas. Example: "1, 3, 5")
   - '-' Avoid check type, the param are formatted as string
-  - 'j' String. Use JSON.parse
 - secured: Hide command from screen & history (default is false)
 - aliases: Used to set deprecated names of the module
 - sanitized: Truncate single quotes (default is true)
@@ -55,5 +55,6 @@ Commands uses promises
 
 See Code: [example_funcs.js](./example_funcs.js)
 
-> Note that all input params are strings or integers. You may use `JSON.parse`
-> to transform strings if you need a usable Javascript object.
+> Note that all input params are strings or numbers. You may use `j` args to
+> parse automatically or `JSON.parse` to transform strings if you need a usable
+> Javascript object.

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -46,6 +46,7 @@ Commands uses promises
   - 'l' Indicates that the next parameter can be a list (a list is a string of
     values separted by commas. Example: "1, 3, 5")
   - '-' Avoid check type, the param are formatted as string
+  - 'j' String. Use JSON.parse
 - secured: Hide command from screen & history (default is false)
 - aliases: Used to set deprecated names of the module
 - sanitized: Truncate single quotes (default is true)

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -38,15 +38,17 @@ Commands uses promises
 - syntax: Command Parameters (For Humans)
   - <> Required
   - [] Optional
-- args: Command Paramerters Types
-  - 's' String
-  - 'i' Number
-  - 'j' String. Using JSON.parse
-  - '?' Indicates that next parameters are optional
-  - '\*' All the rest (unknown) of params are formatted as string
-  - 'l' Indicates that the next parameter can be a list (a list is a string of
-    values separted by commas. Example: "1, 3, 5")
-  - '-' Avoid check type, the param are formatted as string
+- args: Command Arguments
+  - String with the format:
+    "TYPE::NAME_SHORT:NAME_LONG::REQUIRED::DESCRIPTION::DEFAULT_VALUE::STRICT_VALUES"
+    - The 'TYPE' can be:
+      - 's' String
+      - 'i' Number
+      - 'j' String. Using JSON.parse
+      - 'l' Indicates that the next parameter can be a list (a list is a string
+        of values separted by commas. Example: "1, 3, 5")
+      - 'f' None. Used as flag
+      - '-' Avoid check type, the param are formatted as string
 - secured: Hide command from screen & history (default is false)
 - aliases: Used to set deprecated names of the module
 - sanitized: Truncate single quotes (default is true)

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -202,6 +202,6 @@
 /* TRANSITIONS */
 .terminal-transition-topdown {
     top: 0;
-    transition: 700ms;
+    transition: 350ms;
     transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -191,6 +191,14 @@
     color: var(--terminal-screen-extra-info-color);
 }
 
+/** HELP COMMAND **/
+.o_terminal .terminal-info-section {
+    margin-left: 2em;
+}
+.o_terminal .terminal-info-section .terminal-info-description {
+    margin-left: 2em;
+}
+
 /* TRANSITIONS */
 .terminal-transition-topdown {
     top: 0;

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -4,6 +4,7 @@
     --terminal-screen-width: 70%;
     --terminal-screen-width-maximized: 100%;
     --terminal-screen-background-color: black;
+    --terminal-screen-assistant-background-color: #222300;
     --terminal-screen-text-color: lightgray;
     --terminal-screen-font: "Lucida Console", Monaco, monospace;
     --terminal-screen-extra-info-color: darkkhaki;
@@ -109,6 +110,11 @@
 }
 .o_terminal div#terminal_screen .line-array:before {
     content: "- ";
+}
+
+.o_terminal div#terminal_assistant {
+    background-color: var(--terminal-screen-assistant-background-color);
+    font-size: x-small;
 }
 
 .o_terminal .terminal-user-input {

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -22,7 +22,7 @@
     top: -110%;
     transform: translate(-50%, 0);
     width: var(--terminal-screen-width);
-    z-index: 1041;
+    z-index: 1031;
     display: grid; /* Here to force BS4 behavior */
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;
@@ -59,9 +59,11 @@
     color: var(--terminal-title-color);
 }
 
+.o_terminal div#terminal_screen .o_terminal_click {
+    text-decoration: underline;
+}
 .o_terminal div#terminal_screen .o_terminal_click:hover {
     cursor: pointer;
-    text-decoration: underline;
 }
 
 .o_terminal div#terminal_screen .error_message {

--- a/odoo/css/terminal.css
+++ b/odoo/css/terminal.css
@@ -22,7 +22,7 @@
     top: -110%;
     transform: translate(-50%, 0);
     width: var(--terminal-screen-width);
-    z-index: 1031;
+    z-index: 1041;
     display: grid; /* Here to force BS4 behavior */
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;

--- a/odoo/js/core/abstract/longpolling.js
+++ b/odoo/js/core/abstract/longpolling.js
@@ -5,6 +5,9 @@ odoo.define("terminal.core.abstract.Longpolling", function (require) {
     "use strict";
 
     const Class = require("web.Class");
+    const core = require("web.core");
+
+    const _t = core._t;
 
     const AbstractLongPolling = Class.extend({
         _parent: null,
@@ -22,7 +25,7 @@ odoo.define("terminal.core.abstract.Longpolling", function (require) {
          */
         // eslint-disable-next-line
         _onBusNotification: function (notifications) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         /**
@@ -30,7 +33,7 @@ odoo.define("terminal.core.abstract.Longpolling", function (require) {
          */
         // eslint-disable-next-line
         setVerbose: function (status) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         /**
@@ -38,7 +41,7 @@ odoo.define("terminal.core.abstract.Longpolling", function (require) {
          */
         // eslint-disable-next-line
         isVerbose: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         /**
@@ -46,7 +49,7 @@ odoo.define("terminal.core.abstract.Longpolling", function (require) {
          */
         // eslint-disable-next-line
         addChannel: function (name) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         /**
@@ -54,17 +57,17 @@ odoo.define("terminal.core.abstract.Longpolling", function (require) {
          */
         // eslint-disable-next-line
         deleteChannel: function (name) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         startPoll: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         stopPoll: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
     });
 

--- a/odoo/js/core/abstract/screen.js
+++ b/odoo/js/core/abstract/screen.js
@@ -5,6 +5,9 @@ odoo.define("terminal.core.abstract.Screen", function (require) {
     "use strict";
 
     const Class = require("web.Class");
+    const core = require("web.core");
+
+    const _t = core._t;
 
     const AbstractScreen = Class.extend({
         init: function (options) {
@@ -16,94 +19,94 @@ odoo.define("terminal.core.abstract.Screen", function (require) {
         },
 
         destroy: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         getContent: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         getBuffer: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         scrollDown: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         clean: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         cleanInput: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         cleanShadowInput: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         updateInput: function (str) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         updateShadowInput: function (str) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         preventLostInputFocus: function (ev) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         focus: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         getUserInput: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         isPinned: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         /* PRINT */
         flush: function () {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         printHTML: function (html) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         print: function (msg, enl, cls) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         eprint: function (msg, enl) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         printCommand: function (cmd, secured = false) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         printError: function (error, internal = false) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
 
         // eslint-disable-next-line
         printTable: function (columns, tbody) {
-            throw Error("Not Implemented!");
+            throw Error(_t("Not Implemented!"));
         },
     });
 

--- a/odoo/js/core/abstract/screen.js
+++ b/odoo/js/core/abstract/screen.js
@@ -51,6 +51,10 @@ odoo.define("terminal.core.abstract.Screen", function (require) {
             throw Error(_t("Not Implemented!"));
         },
 
+        getInputCaretStartPos: function () {
+            throw Error(_t("Not Implemented!"));
+        },
+
         // eslint-disable-next-line
         updateShadowInput: function (str) {
             throw Error(_t("Not Implemented!"));

--- a/odoo/js/core/command_assistant.js
+++ b/odoo/js/core/command_assistant.js
@@ -1,0 +1,169 @@
+// Copyright 2021 Alexandre Díaz <dev@redneboa.es>
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("terminal.core.CommandAssistant", function (require) {
+    "use strict";
+
+    const Class = require("web.Class");
+    const mixins = require("web.mixins");
+
+    const CommandAssistant = Class.extend(mixins.ParentedMixin, {
+        init: function (parent) {
+            this.setParent(parent);
+            this._parameterReader = parent._parameterReader;
+            this._registeredCmds = parent._registeredCmds;
+        },
+
+        _getAvailableCommandNames: function (scmd) {
+            const cmd_names = Object.keys(this._registeredCmds);
+            return _.filter(cmd_names, (cmd_name) =>
+                cmd_name.startsWith(scmd.cmd)
+            );
+        },
+
+        _getAvailableArguments: function (scmd, arg_name) {
+            const cmd_def = this._registeredCmds[scmd.cmd];
+            const s_arg_name =
+                arg_name && arg_name.substr(arg_name[1] === "-" ? 2 : 1);
+            const arg_infos = [];
+            for (const arg of cmd_def.args) {
+                const arg_info = this._parameterReader.getArgumentInfo(arg);
+                if (!s_arg_name || arg_info.names.long.startsWith(s_arg_name)) {
+                    arg_infos.push(arg_info);
+                }
+            }
+            return arg_infos;
+        },
+
+        _getAvailableParameters: function (scmd, sel_param_index, param) {
+            const cmd_def = this._registeredCmds[scmd.cmd];
+            const prev_param =
+                sel_param_index > 0 && scmd.params[sel_param_index - 1];
+            let arg_info = false;
+            if (!prev_param || prev_param[0] !== "-") {
+                // Its a unnamed parameter
+                const arg = cmd_def.args[sel_param_index];
+                arg_info = arg && this._parameterReader.getArgumentInfo(arg);
+            } else if (prev_param[0] === "-" && prev_param.length > 1) {
+                // Its a named parameter
+                arg_info = this._parameterReader.getArgumentInfoByName(
+                    cmd_def.args,
+                    prev_param.substr(prev_param[1] === "-" ? 2 : 1)
+                );
+            }
+
+            const res_param_infos = [];
+            if (!_.isEmpty(arg_info)) {
+                if (!_.isEmpty(arg_info.strict_values)) {
+                    const def_value = arg_info.default_value;
+                    for (const strict_value of arg_info.strict_values) {
+                        if (!param || String(strict_value).startsWith(param)) {
+                            res_param_infos.push({
+                                value: strict_value,
+                                is_required: arg_info.is_required,
+                                is_default: strict_value === def_value,
+                            });
+                        }
+                    }
+                } else if (
+                    arg_info.default_value &&
+                    String(arg_info.default_value).startsWith(param)
+                ) {
+                    res_param_infos.push({
+                        value: arg_info.default_value,
+                        is_default: true,
+                        is_required: arg_info.is_required,
+                    });
+                }
+            }
+
+            return res_param_infos;
+        },
+
+        getSelectedParameterIndex: function (scmd, caret_pos) {
+            let sel_param_index = null;
+            if (caret_pos <= scmd.cmd.length) {
+                sel_param_index = -1;
+            } else if (caret_pos > scmd.cmdRaw.trim().length) {
+                sel_param_index = scmd.params.length;
+            } else {
+                let offset = scmd.cmd.length + 1;
+                for (const index_param in scmd.params) {
+                    if (
+                        caret_pos >= offset &&
+                        caret_pos <= offset + scmd.params[index_param].length
+                    ) {
+                        sel_param_index = index_param;
+                    }
+                    // +1 because space
+                    offset += scmd.params[index_param].length + 1;
+                }
+            }
+
+            return sel_param_index;
+        },
+
+        getAvailableOptions: function (cmd_raw, caret_pos) {
+            if (_.isEmpty(cmd_raw)) {
+                return [];
+            }
+            const scmd = this._parameterReader.parse(cmd_raw);
+            const sel_param_index = this.getSelectedParameterIndex(
+                scmd,
+                caret_pos
+            );
+            const options = [];
+
+            if (sel_param_index === -1) {
+                // Its a command name
+                const cmd_names = this._getAvailableCommandNames(scmd);
+                for (const cmd_name of cmd_names) {
+                    options.push({
+                        name: cmd_name,
+                        string: cmd_name,
+                        is_command: true,
+                    });
+                }
+            } else if (
+                Object.prototype.hasOwnProperty.call(
+                    this._registeredCmds,
+                    scmd.cmd
+                )
+            ) {
+                const param = scmd.params[sel_param_index];
+                if ((param && param[0] === "-") || sel_param_index === 0) {
+                    // Its a argument
+                    const arg_infos = this._getAvailableArguments(scmd, param);
+                    for (const arg_info of arg_infos) {
+                        options.push({
+                            name: `-${arg_info.names.short}, --${arg_info.names.long}`,
+                            string: `--${arg_info.names.long}`,
+                            is_argument: true,
+                            is_required: arg_info.is_required,
+                        });
+                    }
+                } else {
+                    // Its a parameter
+                    const param_infos = this._getAvailableParameters(
+                        scmd,
+                        sel_param_index,
+                        param
+                    );
+                    for (const param_info of param_infos) {
+                        options.push({
+                            name: param_info.value,
+                            string: param_info.value,
+                            is_paramater: true,
+                            is_default: param_info.is_default,
+                            is_required: param_info.is_required,
+                        });
+                    }
+                }
+            }
+
+            return options;
+        },
+    });
+
+    return CommandAssistant;
+});

--- a/odoo/js/core/compat/v15/common.js
+++ b/odoo/js/core/compat/v15/common.js
@@ -1,0 +1,23 @@
+// Copyright 2021 Alexandre Díaz <dev@redneboa.es>
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+/** Implementations for Odoo 15.0+ **/
+odoo.define("terminal.core.compat.15.Common", function (require) {
+    "use strict";
+
+    const Utils = require("terminal.core.Utils");
+
+    /**
+     * Monkey patch to get correct user id
+     */
+    const origGetUID = Utils.getUID;
+    Utils.getUID = () => {
+        let uid = 0;
+        try {
+            uid = origGetUID();
+        } catch (e) {
+            uid = odoo.__DEBUG__.services["@web/session"].session.user_id;
+        }
+        return uid;
+    };
+});

--- a/odoo/js/core/parameter_generator.js
+++ b/odoo/js/core/parameter_generator.js
@@ -94,7 +94,12 @@ odoo.define("terminal.core.ParameterGenerator", function (require) {
                 let index_b = 0;
                 while (index_b < matches_len) {
                     const match = matches[index_b];
-                    if (match[2] in this._generators) {
+                    if (
+                        Object.prototype.hasOwnProperty.call(
+                            this._generators,
+                            match[2]
+                        )
+                    ) {
                         const gen_val = this._generators[match[2]](
                             ...match.splice(3)
                         );

--- a/odoo/js/core/parameter_reader.js
+++ b/odoo/js/core/parameter_reader.js
@@ -20,6 +20,7 @@ odoo.define("terminal.core.ParameterReader", function (require) {
                 s: this._validateString,
                 i: this._validateInt,
                 j: this._validateJson,
+                f: this._validateInt,
             };
             this._formatters = {
                 s: this._formatString,
@@ -79,10 +80,10 @@ odoo.define("terminal.core.ParameterReader", function (require) {
                 description: descr,
                 default_value:
                     (!_.isEmpty(default_value) &&
-                        this._formatters[ttype](default_value, false)) ||
+                        this._formatters[ttype](default_value, list_mode)) ||
                     undefined,
                 strict_values:
-                    (!_.isEmpty(default_value) &&
+                    (!_.isEmpty(s_strict_values) &&
                         this._formatters[ttype](s_strict_values, true)) ||
                     undefined,
                 is_required: Boolean(Number(is_required)),

--- a/odoo/js/core/parameter_reader.js
+++ b/odoo/js/core/parameter_reader.js
@@ -298,7 +298,7 @@ odoo.define("terminal.core.ParameterReader", function (require) {
 
                     try {
                         JSON.parse(param_sa);
-                    } catch (e) {
+                    } catch (err) {
                         is_valid = false;
                         break;
                     }
@@ -309,7 +309,7 @@ odoo.define("terminal.core.ParameterReader", function (require) {
 
             try {
                 JSON.parse(param);
-            } catch (e) {
+            } catch (err) {
                 return false;
             }
             return true;

--- a/odoo/js/core/parameter_reader.js
+++ b/odoo/js/core/parameter_reader.js
@@ -166,7 +166,7 @@ odoo.define("terminal.core.ParameterReader", function (require) {
                 checkedCount !== params.length ||
                 checkedCount < this._getNumRequiredArgs(args)
             ) {
-                throw new Error(_t("Invalid command parameters"));
+                throw _t("Invalid command parameters");
             }
 
             return formatted_params;

--- a/odoo/js/core/parameter_reader.js
+++ b/odoo/js/core/parameter_reader.js
@@ -177,7 +177,6 @@ odoo.define("terminal.core.ParameterReader", function (require) {
             let scmd = Array.from(match, (x) => x[0]);
             const cmd = scmd[0];
             scmd = scmd.slice(1);
-            const rawParams = scmd.join(" ");
             let params = _.map(scmd, (item) => {
                 let nvalue = item;
                 if (item[0] === '"' || item[0] === "'") {
@@ -195,7 +194,7 @@ odoo.define("terminal.core.ParameterReader", function (require) {
 
             return {
                 cmd: cmd,
-                rawParams: rawParams,
+                cmdRaw: cmd_raw,
                 params: params,
             };
         },
@@ -263,6 +262,9 @@ odoo.define("terminal.core.ParameterReader", function (require) {
                     if (!_.isNull(formatted_param)) {
                         kwargs[s_arg_long_name] = formatted_param;
                         ++checkedCount;
+                        if (arg_info.is_required) {
+                            ++checkedRequiredCount;
+                        }
                         continue;
                     }
 

--- a/odoo/js/core/screen.js
+++ b/odoo/js/core/screen.js
@@ -103,7 +103,6 @@ odoo.define("terminal.core.Screen", function (require) {
             if (!this.$screen || !this.$screen.length) {
                 return;
             }
-            // Make browser happy... split buffer
             this.$screen.append(
                 this._buff.splice(0, this._max_buff_lines).join("")
             );
@@ -155,38 +154,23 @@ odoo.define("terminal.core.Screen", function (require) {
                 return;
             }
             let error_msg = error;
-            if (
-                typeof error === "object" &&
-                "data" in error &&
-                "exception_type" in error.data
-            ) {
+            if (typeof error === "object" && "data" in error) {
                 // It's an Odoo error report
                 const error_id = new Date().getTime();
                 error_msg = this._templates.render("ERROR_MESSAGE", {
                     error_name: utils.encodeHTML(error.data.name),
                     error_message: utils.encodeHTML(error.data.message),
                     error_id: error_id,
-                    exception_type: error.data.exception_type,
-                    context: JSON.stringify(error.data.context),
-                    args: JSON.stringify(error.data.arguments),
-                    debug: utils.encodeHTML(error.data.debug),
-                });
-                ++this._errorCount;
-            } else if (
-                typeof error === "object" &&
-                "data" in error &&
-                "type" in error.data
-            ) {
-                // It's an Odoo error report
-                const error_id = new Date().getTime();
-                error_msg = this._templates.render("ERROR_MESSAGE", {
-                    error_name: utils.encodeHTML(error.data.objects[1]),
-                    error_message: utils.encodeHTML(error.message),
-                    error_id: error_id,
-                    exception_type: error.data.type,
-                    context: "",
-                    args: "",
-                    debug: utils.encodeHTML(error.data.debug),
+                    exception_type:
+                        error.data.exception_type || error.data.type,
+                    context:
+                        error.data.context &&
+                        JSON.stringify(error.data.context),
+                    args:
+                        error.data.arguments &&
+                        JSON.stringify(error.data.arguments),
+                    debug:
+                        error.data.debug && utils.encodeHTML(error.data.debug),
                 });
                 ++this._errorCount;
             } else if (

--- a/odoo/js/core/screen.js
+++ b/odoo/js/core/screen.js
@@ -49,7 +49,12 @@ odoo.define("terminal.core.Screen", function (require) {
 
         clean: function () {
             this.$screen.html("");
-            if ("onCleanScreen" in this._options) {
+            if (
+                Object.prototype.hasOwnProperty.call(
+                    this._options,
+                    "onCleanScreen"
+                )
+            ) {
                 this._options.onCleanScreen(this.getContent());
             }
         },
@@ -110,7 +115,12 @@ odoo.define("terminal.core.Screen", function (require) {
             this.scrollDown();
 
             if (this._buff.length === 0) {
-                if ("onSaveScreen" in this._options) {
+                if (
+                    Object.prototype.hasOwnProperty.call(
+                        this._options,
+                        "onSaveScreen"
+                    )
+                ) {
                     this._options.onSaveScreen(this.getContent());
                 }
                 this._flushing = false;
@@ -154,7 +164,10 @@ odoo.define("terminal.core.Screen", function (require) {
                 return;
             }
             let error_msg = error;
-            if (typeof error === "object" && "data" in error) {
+            if (
+                typeof error === "object" &&
+                Object.prototype.hasOwnProperty.call(error, "data")
+            ) {
                 // It's an Odoo error report
                 const error_id = new Date().getTime();
                 error_msg = this._templates.render("ERROR_MESSAGE", {
@@ -175,7 +188,7 @@ odoo.define("terminal.core.Screen", function (require) {
                 ++this._errorCount;
             } else if (
                 typeof error === "object" &&
-                "status" in error &&
+                Object.prototype.hasOwnProperty.call(error, "status") &&
                 error.status !== "200"
             ) {
                 // It's an Odoo error report

--- a/odoo/js/core/storage.js
+++ b/odoo/js/core/storage.js
@@ -5,6 +5,10 @@ odoo.define("terminal.core.Storage", function (require) {
     "use strict";
 
     const Class = require("web.Class");
+    const core = require("web.core");
+
+    const _t = core._t;
+    const _lt = core._lt;
 
     const AbstractStorage = Class.extend({
         _parent: null,
@@ -21,7 +25,7 @@ odoo.define("terminal.core.Storage", function (require) {
          */
         // eslint-disable-next-line
         getItem: function (item) {
-            throw Error("Not Implemented!");
+            throw Error(_lt("Not Implemented!"));
         },
 
         /**
@@ -30,7 +34,7 @@ odoo.define("terminal.core.Storage", function (require) {
          */
         // eslint-disable-next-line
         setItem: function (item, value, on_error = false) {
-            throw Error("Not Implemented!");
+            throw Error(_lt("Not Implemented!"));
         },
 
         /**
@@ -38,7 +42,7 @@ odoo.define("terminal.core.Storage", function (require) {
          */
         // eslint-disable-next-line
         removeItem: function (item) {
-            throw Error("Not Implemented!");
+            throw Error(_lt("Not Implemented!"));
         },
 
         /**
@@ -53,14 +57,18 @@ odoo.define("terminal.core.Storage", function (require) {
             }
             return (
                 "<span style='color:navajowhite'>" +
-                "<strong>WARNING:</strong> Clear the " +
+                `<strong>${_t("WARNING:")}</strong> ${_t("Clear the")} ` +
                 "<b class='o_terminal_click o_terminal_cmd' " +
-                "data-cmd='clear screen' style='color:orange;'>screen</b> " +
-                "or/and " +
+                `data-cmd='clear screen' style='color:orange;'>${_t(
+                    "screen"
+                )}</b> ` +
+                `${_t("or/and")} ` +
                 "<b class='o_terminal_click o_terminal_cmd' " +
                 "data-cmd='clear history' style='color:orange;'>" +
-                "history</b> " +
-                "to free storage space. Browser <u>Storage Quota Exceeded</u>" +
+                `${_t("history")}</b> ` +
+                _t(
+                    "to free storage space. Browser <u>Storage Quota Exceeded</u>"
+                ) +
                 " 😭 </strong><br>"
             );
         },

--- a/odoo/js/core/template_manager.js
+++ b/odoo/js/core/template_manager.js
@@ -62,8 +62,6 @@ odoo.define("terminal.core.TemplateManager", function (require) {
                 "<%= tbody %>" +
                 "</tbody>" +
                 "</table>",
-            TABLE_BODY_CMD:
-                "<td><span class='o_terminal_click o_terminal_view' data-resid='<%= id %>' data-model='<%= model %>'>#<%= id %></span></td>",
             TABLE_SEARCH_ID:
                 "<td><span class='o_terminal_click o_terminal_view' data-resid='<%= id %>' data-model='<%= model %>'>#<%= id %></span></td>",
             WHOAMI:

--- a/odoo/js/core/utils.js
+++ b/odoo/js/core/utils.js
@@ -57,11 +57,16 @@ odoo.define("terminal.core.Utils", function () {
         }
     };
 
+    const getUID = () => {
+        return odoo.session_info.uid || odoo.session_info.user_id;
+    };
+
     return {
         encodeHTML: encodeHTML,
         genHash: genHash,
         hex2rgb: hex2rgb,
         unescapeSlashes: unescapeSlashes,
         save2File: save2File,
+        getUID: getUID,
     };
 });

--- a/odoo/js/core/utils.js
+++ b/odoo/js/core/utils.js
@@ -58,24 +58,31 @@ odoo.define("terminal.core.Utils", function (require) {
     };
 
     const file2Base64 = () => {
-        const input = window.document.createElement("input");
-        input.type = "file";
-        document.body.appendChild(input);
+        const input_elm = window.document.createElement("input");
+        input_elm.type = "file";
+        document.body.appendChild(input_elm);
+        const onBodyFocus = (reject) => {
+            if (!input_elm.value.length) {
+                return reject("Aborted by user. No file given...");
+            }
+        };
 
         return new Promise((resolve, reject) => {
-            input.onchange = (e) => {
+            window.addEventListener("focus", onBodyFocus.bind(this, reject));
+            input_elm.onchange = (e) => {
                 const file = e.target.files[0];
                 const reader = new FileReader();
                 reader.readAsDataURL(file);
 
                 reader.onerror = reject;
-                reader.onload = (readerEvent) => {
-                    return resolve(readerEvent.target.result);
-                };
+                reader.onabort = reject;
+                reader.onload = (readerEvent) =>
+                    resolve(readerEvent.target.result);
             };
-            input.click();
+            input_elm.click();
         }).finally(() => {
-            document.body.removeChild(input);
+            window.removeEventListener("focus", onBodyFocus);
+            document.body.removeChild(input_elm);
         });
     };
 

--- a/odoo/js/functions/backend.js
+++ b/odoo/js/functions/backend.js
@@ -52,7 +52,7 @@ odoo.define("terminal.functions.Backend", function (require) {
 
         _cmdViewModelRecord: function (kwargs) {
             const context = this._getContext({
-                form_view_ref: kwargs.ref,
+                form_view_ref: kwargs.ref || false,
             });
             if (kwargs.id) {
                 return this.do_action({

--- a/odoo/js/functions/backend.js
+++ b/odoo/js/functions/backend.js
@@ -19,23 +19,26 @@ odoo.define("terminal.functions.Backend", function (require) {
                 definition: "View model record/s",
                 callback: this._cmdViewModelRecord,
                 detail: "Open model record in form view or records in list view.",
-                syntax: "<STRING: MODEL NAME> [INT: RECORD ID] [STRING: VIEW REF]",
-                args: "s?is",
-                example: "res.partner 10 base.view_partner_simple_form",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "i::i:id::0::The record id",
+                    "s::r:ref::0::The view reference name",
+                ],
+                example:
+                    "-m res.partner -i 10 -r base.view_partner_simple_form",
             });
             this.registerCommand("settings", {
                 definition: "Open settings page",
                 callback: this._cmdOpenSettings,
-                detail:
-                    "Open settings page." +
-                    "<br>[MODULE NAME] The module technical name (default is 'general_settings')",
-                syntax: "[STRING: MODULE NAME]",
-                args: "?s",
-                example: "sale_management",
+                detail: "Open settings page.",
+                args: [
+                    "s::m:module::0::The module technical name::general_settings",
+                ],
+                example: "-m sale_management",
             });
         },
 
-        _cmdOpenSettings: function (module = "general_settings") {
+        _cmdOpenSettings: function (kwargs) {
             return this.do_action({
                 name: "Settings",
                 type: "ir.actions.act_window",
@@ -43,34 +46,34 @@ odoo.define("terminal.functions.Backend", function (require) {
                 view_mode: "form",
                 views: [[false, "form"]],
                 target: "inline",
-                context: {module: module},
+                context: {module: kwargs.module},
             }).then(() => this.doHide());
         },
 
-        _cmdViewModelRecord: function (model, id, view_ref = false) {
+        _cmdViewModelRecord: function (kwargs) {
             const context = this._getContext({
-                form_view_ref: view_ref,
+                form_view_ref: kwargs.ref,
             });
-            if (id) {
+            if (kwargs.id) {
                 return this.do_action({
                     type: "ir.actions.act_window",
                     name: "View Record",
-                    res_model: model,
-                    res_id: id,
+                    res_model: kwargs.model,
+                    res_id: kwargs.id,
                     views: [[false, "form"]],
                     target: "new",
                     context: context,
                 }).then(() => this.doHide());
             }
             new dialogs.SelectCreateDialog(this, {
-                res_model: model,
+                res_model: kwargs.model,
                 title: "Select a record",
                 disable_multiple_selection: true,
                 on_selected: (records) => {
                     this.do_action({
                         type: "ir.actions.act_window",
                         name: "View Record",
-                        res_model: model,
+                        res_model: kwargs.model,
                         res_id: records[0].id,
                         views: [[false, "form"]],
                         target: "new",

--- a/odoo/js/functions/backend.js
+++ b/odoo/js/functions/backend.js
@@ -18,10 +18,8 @@ odoo.define("terminal.functions.Backend", function (require) {
             this.registerCommand("view", {
                 definition: "View model record/s",
                 callback: this._cmdViewModelRecord,
-                detail:
-                    "Open model record in form view or records in list view.",
-                syntax:
-                    "<STRING: MODEL NAME> [INT: RECORD ID] [STRING: VIEW REF]",
+                detail: "Open model record in form view or records in list view.",
+                syntax: "<STRING: MODEL NAME> [INT: RECORD ID] [STRING: VIEW REF]",
                 args: "s?is",
                 example: "res.partner 10 base.view_partner_simple_form",
             });

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -24,286 +24,262 @@ odoo.define("terminal.functions.Common", function (require) {
                 definition: "Create new record",
                 callback: this._cmdCreateModelRecord,
                 detail: "Open new model record in form view or directly.",
-                syntax: '<STRING: MODEL NAME> "[DICT: VALUES]"',
-                args: "s?j",
-                example: "res.partner \"{'name': 'Poldoore'}\"",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "j::v:value::0::The values to write",
+                ],
+                example: "-m res.partner -v \"{'name': 'Poldoore'}\"",
             });
             this.registerCommand("unlink", {
                 definition: "Unlink record",
                 callback: this._cmdUnlinkModelRecord,
                 detail: "Delete a record.",
-                syntax: "<STRING: MODEL NAME> <INT: RECORD ID or LIST OF IDs>",
-                args: "sli",
-                example: "res.partner 10,4,2",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "li::i:id::1::The record id's",
+                ],
+                example: "-m res.partner -i 10,4,2",
             });
             this.registerCommand("write", {
                 definition: "Update record values",
                 callback: this._cmdWriteModelRecord,
                 detail: "Update record values.",
-                syntax:
-                    "<STRING: MODEL NAME> <INT: RECORD ID or LIST OF IDs> " +
-                    '"<DICT: NEW VALUES>"',
-                args: "slij",
-                example: "res.partner 10,4,2 \"{'street': 'Diagon Alley'}\"",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "li::i:id::1::The record id's",
+                    "j::v:value::1::The values to write",
+                ],
+                example:
+                    "-m res.partner -i 10,4,2 -v \"{'street': 'Diagon Alley'}\"",
             });
             this.registerCommand("search", {
                 definition: "Search model record/s",
                 callback: this._cmdSearchModelRecord,
-                detail:
-                    "Launch orm search query.<br>[FIELDS] " +
-                    "are separated by commas (without spaces) and by default " +
-                    "is 'display_name'. Can use '*' to show all fields of the model" +
-                    "<br>[LIMIT] can be zero (no limit)" +
-                    "<br>[ORDER] A list of orders separated by comma (Example: 'age DESC, email')",
-                syntax:
-                    "<STRING: MODEL NAME> [STRING: FIELDS] " +
-                    '"[ARRAY: DOMAIN]" [INT: LIMIT] [INT: OFFSET] ' +
-                    '"[STRING: ORDER]"',
-                args: "s?lsjiis",
-                example: "res.partner * [] 100 5 'id DESC, name'",
+                detail: "Launch orm search query",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "ls::f:field::0::The field names to request<br/>Can use '*' to show all fields of the model::display_name",
+                    "j::d:domain::0::The domain::[]",
+                    "i::l:limit::0::The limit of records to request",
+                    "i::of:offset::0::The offset (from)<br/>Can be zero (no limit)",
+                    "s::o:order::0::The order<br/>A list of orders separated by comma (Example: 'age DESC, email')",
+                    "f::more:more::0::Flag to indicate that show more results",
+                ],
+                example: "-m res.partner -f * -l 100 -of 5 -o 'id DESC, name'",
             });
             this.registerCommand("call", {
                 definition: "Call model method",
                 callback: this._cmdCallModelMethod,
                 detail: "Call model method. Remember: Methods with @api.model decorator doesn't need the id.",
-                syntax:
-                    '<STRING: MODEL> <STRING: METHOD> "[ARRAY: ARGS]" ' +
-                    '"[DICT: KWARGS]"',
-                args: "ss?jj",
-                example: "res.partner can_edit_vat [8]",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "s::c:call::1::The method name to call",
+                    "j::a:argument::0::The arguments list::[]",
+                    "j::k:kwarg::0::The arguments dictionary::{}",
+                ],
+                example: "-m res.partner -c can_edit_vat -a [8]",
             });
             this.registerCommand("upgrade", {
                 definition: "Upgrade a module",
                 callback: this._cmdUpgradeModule,
                 detail: "Launch upgrade module process.",
-                syntax: "<STRING: MODULE NAME>",
-                args: "s",
-                example: "contacts",
+                args: ["s::m:module::1::The module technical name"],
+                example: "-m contacts",
             });
             this.registerCommand("install", {
                 definition: "Install a module",
                 callback: this._cmdInstallModule,
                 detail: "Launch module installation process.",
-                syntax: "<STRING: MODULE NAME>",
-                args: "s",
-                example: "contacts",
+                args: ["s::m:module::1::The module technical name"],
+                example: "-m contacts",
             });
             this.registerCommand("uninstall", {
                 definition: "Uninstall a module",
                 callback: this._cmdUninstallModule,
                 detail: "Launch module deletion process.",
-                syntax: "<STRING: MODULE NAME>",
-                args: "s",
-                exmaple: "contacts",
+                args: ["s::m:module::1::The module technical name"],
+                exmaple: "-m contacts",
             });
             this.registerCommand("reload", {
                 definition: "Reload current page",
                 callback: this._cmdReloadPage,
                 detail: "Reload current page.",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("debug", {
                 definition: "Set debug mode",
                 callback: this._cmdSetDebugMode,
-                detail:
-                    "Set debug mode:<br>- 0: Disabled<br>- 1: " +
-                    "Enabled<br>- 2: Enabled with Assets",
-                syntax: "<INT: MODE>",
-                args: "i",
-                example: "2",
+                detail: "Set debug mode",
+                args: [
+                    "i::m:mode::1::The mode<br>- 0: Disabled<br>- 1: Enabled<br>- 2: Enabled with Assets::::0:1:2",
+                ],
+                example: "-m 2",
             });
             this.registerCommand("action", {
                 definition: "Call action",
                 callback: this._cmdCallAction,
-                detail:
-                    "Call action.<br>&lt;ACTION&gt; Can be an " +
-                    "string, number or object.",
-                syntax: '"<STRING|DICT: ACTION>"',
-                args: "*",
-                example: "134",
+                detail: "Call action",
+                args: [
+                    "-::a:action::1::The action to launch<br/>Can be an string, number or object",
+                ],
+                example: "-a 134",
             });
             this.registerCommand("post", {
                 definition: "Send POST request",
                 callback: this._cmdPostData,
                 detail: "Send POST request to selected endpoint",
-                syntax: '<STRING: ENDPOINT> "<DICT: DATA>"',
-                args: "sj",
-                example: "/web/endpoint \"{'the_example': 42}\"",
+                args: [
+                    "s::e:endpoint::1::The endpoint",
+                    "j::d:data::1::The data",
+                ],
+                example: "-e /web/endpoint -d \"{'the_example': 42}\"",
             });
             this.registerCommand("whoami", {
                 definition: "Know current user login",
                 callback: this._cmdShowWhoAmI,
                 detail: "Shows current user login",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("caf", {
                 definition: "Check model fields access",
                 callback: this._cmdCheckFieldAccess,
                 detail: "Show readable/writeable fields of the selected model",
-                syntax: '<STRING: MODEL> "[LIST: FIELDS]"',
-                args: "s?ls",
-                example: 'res.partner "name,street"',
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "ls::f:field::0::The field names to request",
+                ],
+                example: "-m res.partner -f name,street",
             });
             this.registerCommand("cam", {
                 definition: "Check model access",
                 callback: this._cmdCheckModelAccess,
                 detail:
                     "Show access rights for the selected operation on the" +
-                    " selected model" +
-                    "<br>&lt;OPERATION&gt; Can be 'create', 'read', 'write'" +
-                    " or 'unlink'",
-                syntax: "<STRING: MODEL> <STRING: OPERATION>",
-                args: "ss",
-                example: "res.partner read",
+                    " selected model",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "s::o:operation::1::The operation to do::::create:read:write:unlink",
+                ],
+                example: "-m res.partner -o read",
             });
             this.registerCommand("lastseen", {
                 definition: "Know user presence",
                 callback: this._cmdLastSeen,
                 detail: "Show users last seen",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("read", {
                 definition: "Search model record",
                 callback: this._cmdSearchModelRecordId,
-                detail:
-                    "Launch orm search query.<br>[FIELDS] " +
-                    "are separated by commas (without spaces) and by default " +
-                    "is 'display_name'. Can use '*' to show all fields.",
-                syntax:
-                    "<STRING: MODEL NAME> <INT: RECORD ID or LIST OF IDs> " +
-                    "[STRING: FIELDS]",
-                args: "sli?ls",
-                example: "res.partner 10,4,2 name,street",
+                detail: "Launch orm search query.",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "li::i:id::1::The record id's",
+                    "ls::f:field::0::The fields to request<br/>Can use '*' to show all fields::display_name",
+                ],
+                example: "-m res.partner -i 10,4,2 -f name,street",
             });
             this.registerCommand("context", {
                 definition: "Operations over session context dictionary",
                 callback: this._cmdContextOperation,
-                detail:
-                    "Operations over session context dictionary." +
-                    "<br>[OPERATION] can be 'read', 'write' or 'set'. " +
-                    "By default is 'read'. ",
-                syntax: '[STRING: OPERATION] "[DICT: VALUES]" ',
-                args: "?sj",
-                example: "write \"{'the_example': 1}\"",
+                detail: "Operations over session context dictionary.",
+                args: [
+                    "s::o:operation::0::The operation to do::read::read:write:set",
+                    "j::v:value::0::The values",
+                ],
+                example: "-o write -v \"{'the_example': 1}\"",
             });
             this.registerCommand("version", {
                 definition: "Know Odoo version",
                 callback: this._cmdShowOdooVersion,
                 detail: "Shows Odoo version",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("longpolling", {
                 definition: "Long-Polling operations",
                 callback: this._cmdLongpolling,
-                detail:
-                    "Operations over long-polling." +
-                    "<br>[OPERATION] can be 'verbose', 'off', 'add_channel'," +
-                    " 'del_channel', 'start', 'stop' or empty. " +
-                    "If empty, prints current value." +
-                    "<br> - verbose > Print incoming notificacions" +
-                    "<br> - off > Stop verbose mode" +
-                    "<br> - add_channel > Add a channel to listen" +
-                    "<br> - del_channel > Delete a listening channel" +
-                    "<br> - start > Start client longpolling service" +
-                    "<br> - stop > Stop client longpolling service",
-                syntax: "[STRING: OPERATION] [STRING: PARAM1]",
-                args: "?ss",
+                detail: "Operations over long-polling.",
+                args: [
+                    "s::o:operation::0::The operation to do<br>- verbose > Print incoming notificacions<br>- off > Stop verbose mode<br>- add_channel > Add a channel to listen<br>- del_channel > Delete a listening channel<br>- start > Start client longpolling service<br> - stop > Stop client longpolling service::::verbose:off:add_channel:del_channel:start:stop",
+                    "s::p:param::0::The parameter",
+                ],
                 example: "add_channel example_channel",
             });
             this.registerCommand("login", {
                 definition: "Login as...",
                 callback: this._cmdLoginAs,
-                detail:
-                    "Login as selected user." +
-                    "<br>&lt;DATABASE&gt; Can be '*' to use current database" +
-                    "<br>&lt;LOGIN&gt; Can be optionally preceded by the '-'" +
-                    " character and it will be used for password too",
-                syntax: "<STRING: DATABASE> <STRING: LOGIN> [STRING: PASSWORD]",
-                args: "ss?s",
+                detail: "Login as selected user.",
+                args: [
+                    "s::d:database::1::The database<br/>Can be '*' to use current database",
+                    "s::u:user::1::The login<br/>Can be optionally preceded by the '#' character and it will be used for password too",
+                    "s::p:password::0::The password",
+                ],
                 secured: true,
-                example: "devel -admin",
+                example: "-d devel -u #admin",
             });
             this.registerCommand("uhg", {
                 definition: "Check if user is in the selected groups",
                 callback: this._cmdUserHasGroups,
-                detail:
-                    "Check if user is in the selected groups." +
-                    "<br>&lt;GROUPS&gt; A list of groups separated by " +
-                    "commas, a group can be optionally preceded by '!' to " +
-                    "say 'is not in group'",
-                syntax: "<STRING: GROUPS>",
-                args: "s",
-                example: "base.group_user",
+                detail: "Check if user is in the selected groups.",
+                args: [
+                    "ls::g:group::1::The technical name of the group<br/>A group can be optionally preceded by '!' to say 'is not in group'",
+                ],
+                example: "-g base.group_user",
             });
             this.registerCommand("dblist", {
                 definition: "Show database names",
                 callback: this._cmdShowDBList,
                 detail: "Show database names",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("jstest", {
                 definition: "Launch JS Tests",
                 callback: this._cmdJSTest,
-                detail:
-                    "Runs js tests in desktop or mobile mode for the selected module." +
-                    "<br>&lt;MODULE&gt; Module technical name" +
-                    "<br>&lt;MODE&gt; Can be 'desktop' or 'mobile' (By default is 'desktop')",
-                syntax: "<STRING: MODULE> <STRING: MODE>",
-                args: "?ss",
-                example: "web mobile",
+                detail: "Runs js tests in desktop or mobile mode for the selected module.",
+                args: [
+                    "s::m:module::0::The module technical name",
+                    "s::d:device::0::The device to test::desktop::desktop:mobile",
+                ],
+                example: "-m web -d mobile",
             });
             this.registerCommand("tour", {
                 definition: "Launch Tour",
                 callback: this._cmdRunTour,
-                detail:
-                    "Runs the selected tour. If no tour given, prints all available tours." +
-                    "<br>[TOUR NAME] Tour Name",
-                syntax: "[STRING: TOUR NAME]",
-                args: "?s",
-                example: "mail_tour",
+                detail: "Runs the selected tour. If no tour given, prints all available tours.",
+                args: ["s::n:name::0::The tour technical name"],
+                example: "-n mail_tour",
             });
             this.registerCommand("json", {
                 definition: "Send POST JSON",
                 callback: this._cmdPostJSONData,
                 detail: "Sends HTTP POST 'application/json' request",
-                syntax: '<STRING: ENDPOINT> "<DICT: DATA>"',
-                args: "sj",
+                args: [
+                    "s::e:endpoint::1::The endpoint",
+                    "j::d:data::1::The data to send",
+                ],
                 example: "/web/endpoint \"{'the_example': 42}\"",
             });
             this.registerCommand("depends", {
                 definition: "Know modules that depends on the given module",
                 callback: this._cmdModuleDepends,
                 detail: "Show a list of the modules that depends on the given module",
-                syntax: "<STRING: MODULE NAME>",
-                args: "s",
+                args: ["s::m:module::0::The module technical name"],
                 example: "base",
             });
             this.registerCommand("ual", {
                 definition: "Update apps list",
                 callback: this._cmdUpdateAppList,
                 detail: "Update apps list",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("logout", {
                 definition: "Log out",
                 callback: this._cmdLogOut,
                 detail: "Session log out",
-                syntax: "",
-                args: "",
             });
             this.registerCommand("count", {
                 definition:
                     "Gets number of records from the given model in the selected domain",
                 callback: this._cmdCount,
                 detail: "Gets number of records from the given model in the selected domain",
-                syntax: '<STRING: MODEL> "[ARRAY: DOMAIN]"',
-                args: "s?j",
+                args: [
+                    "s::m:model::1::The model technical name",
+                    "j::d:domain::0::The domain::[]",
+                ],
                 example: "res.partner ['name', '=ilike', 'A%']",
             });
             this.registerCommand("ref", {
@@ -311,44 +287,51 @@ odoo.define("terminal.functions.Common", function (require) {
                     "Show the referenced model and id of the given xmlid's",
                 callback: this._cmdRef,
                 detail: "Show the referenced model and id of the given xmlid's",
-                syntax: "<LIST: STRING XML ID>",
-                args: "ls",
-                example: "base.main_company,base.model_res_partner",
+                args: ["ls::x:xmlid::1::The XML-ID"],
+                example: "-x base.main_company,base.model_res_partner",
             });
-            this.registerCommand("pot", {
+            this.registerCommand("lang", {
                 definition: "Operations over translations",
-                callback: this._cmdPot,
-                detail:
-                    "Operations over translations." +
-                    "<br>[OPERATION] can be 'export', 'import', 'languages'." +
-                    "<br>[FORMAT] vanilla formats are 'po' and 'csv'. (Default is 'po')",
-                syntax: "<STRING: OPERATION> [STRING: LANGUAGE] [LIST: TECHNICAL MODEL NAMES] [STRING: FORMAT] [INT: OVERWRITE]",
-                args: "s?slsi",
-                example: "export en_US discuss",
+                callback: this._cmdLang,
+                detail: "Operations over translations.",
+                args: [
+                    "s::o:operation::1::The operation::::export:import:list",
+                    "s::l:lang::0::The language<br/>Can use '__new__' for new language (empty translation template)",
+                    "ls::m:module::0::The technical module name",
+                    "s::f:format::0::The format to use::po::po:csv",
+                    "s::n:name::0::The language name",
+                    "f::no-overwrite:no-overwrite::0::Flag to indicate dont overwrite current translations",
+                ],
+                example: "-o export -l en_US -m mail",
             });
         },
 
-        _cmdPot: function (
-            operation,
-            lang = false,
-            module_names = [],
-            format = "po",
-            overwrite = true
-        ) {
+        _cmdLang: function (kwargs) {
             return new Promise(async (resolve, reject) => {
                 try {
-                    if (operation === "export") {
-                        if (lang && _.isEmpty(module_names)) {
-                            return reject("Need the technical module name(s)");
-                        } else if (!lang && _.isEmpty(module_names)) {
-                            return this.do_action(
-                                "base.action_wizard_lang_export"
+                    const is_empty_args = _.chain(kwargs)
+                        .omit(["operation", "format"])
+                        .isEmpty()
+                        .value();
+                    if (kwargs.operation === "export") {
+                        if (is_empty_args) {
+                            return resolve(
+                                this.do_action("base.action_wizard_lang_export")
+                            );
+                        }
+                        if (
+                            !kwargs.lang ||
+                            !kwargs.format ||
+                            _.isEmpty(kwargs.module)
+                        ) {
+                            return reject(
+                                "'export' operation needs the following arguments: --lang, --format, --module"
                             );
                         }
                         // Get module ids
                         let module_ids = await rpc.query({
                             method: "search_read",
-                            domain: [["name", "in", module_names]],
+                            domain: [["name", "in", kwargs.module]],
                             fields: ["id"],
                             model: "ir.module.module",
                             kwargs: {context: this._getContext()},
@@ -364,8 +347,8 @@ odoo.define("terminal.functions.Common", function (require) {
                             args: [
                                 {
                                     state: "choose",
-                                    format: format,
-                                    lang: lang,
+                                    format: kwargs.format,
+                                    lang: kwargs.lang,
                                     modules: [[6, false, module_ids]],
                                 },
                             ],
@@ -405,11 +388,22 @@ odoo.define("terminal.functions.Common", function (require) {
                         );
 
                         return resolve(action);
-                    }
-                    if (operation === "import") {
-                        if (!lang && _.isEmpty(module_names)) {
-                            return this.do_action(
-                                "base.action_wizard_lang_import"
+                    } else if (kwargs.operation === "import") {
+                        if (is_empty_args) {
+                            return resolve(
+                                this.do_action(
+                                    "base.action_view_base_import_language"
+                                )
+                            );
+                        }
+                        if (
+                            !kwargs.name ||
+                            !kwargs.lang ||
+                            !kwargs.format ||
+                            _.isEmpty(kwargs.module)
+                        ) {
+                            return reject(
+                                "'import' operation needs the following arguments: --name, --lang, --format, --module"
                             );
                         }
                         // Get file content
@@ -420,10 +414,10 @@ odoo.define("terminal.functions.Common", function (require) {
                             model: "base.language.import",
                             args: [
                                 {
-                                    name: "CHANGE ME!",
-                                    code: lang,
-                                    filename: `${lang}.${format}`,
-                                    overwrite: overwrite,
+                                    name: kwargs.name,
+                                    code: kwargs.lang,
+                                    filename: `${kwargs.lang}.${kwargs.format}`,
+                                    overwrite: !kwargs.no_overwrite,
                                     data: file64,
                                 },
                             ],
@@ -446,13 +440,13 @@ odoo.define("terminal.functions.Common", function (require) {
                             );
                         }
                         return resolve(status);
-                    } else if (operation === "languages") {
+                    } else if (kwargs.operation === "list") {
                         const langs = await rpc.query({
                             method: "get_installed",
                             model: "res.lang",
                             kwargs: {context: this._getContext()},
                         });
-                        for (lang of langs) {
+                        for (const lang of langs) {
                             this.screen.print(` - ${lang[0]} (${lang[1]})`);
                         }
                         return resolve(langs);
@@ -464,9 +458,9 @@ odoo.define("terminal.functions.Common", function (require) {
             });
         },
 
-        _cmdRef: function (xmlids) {
+        _cmdRef: function (kwargs) {
             const tasks = [];
-            for (const xmlid of xmlids) {
+            for (const xmlid of kwargs.xmlid) {
                 tasks.push(
                     rpc
                         .query({
@@ -501,12 +495,12 @@ odoo.define("terminal.functions.Common", function (require) {
             });
         },
 
-        _cmdCount: function (model, domain = []) {
+        _cmdCount: function (kwargs) {
             return rpc
                 .query({
                     method: "search_count",
-                    model: model,
-                    args: [domain],
+                    model: kwargs.model,
+                    args: [kwargs.domain],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
@@ -533,12 +527,12 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdModuleDepends: function (module_name) {
+        _cmdModuleDepends: function (kwargs) {
             return rpc
                 .query({
                     method: "onchange_module",
                     model: "res.config.settings",
-                    args: [false, false, module_name],
+                    args: [false, false, kwargs.module],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
@@ -554,11 +548,11 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdPostJSONData: function (url, data) {
+        _cmdPostJSONData: function (kwargs) {
             return rpc
                 .query({
-                    route: url,
-                    params: data,
+                    route: kwargs.endpoint,
+                    params: kwargs.data,
                 })
                 .then((result) => {
                     this.screen.print(result);
@@ -566,13 +560,13 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdRunTour: function (tour_name) {
+        _cmdRunTour: function (kwargs) {
             const tour_names = Object.keys(tour.tours);
-            if (tour_name) {
-                if (tour_names.indexOf(tour_name) === -1) {
+            if (kwargs.name) {
+                if (tour_names.indexOf(kwargs.name) === -1) {
                     this.screen.printError("The given tour doesn't exists!");
                 } else {
-                    odoo.__DEBUG__.services["web_tour.tour"].run(tour_name);
+                    odoo.__DEBUG__.services["web_tour.tour"].run(kwargs.name);
                     this.screen.print("Running tour...");
                 }
             } else if (tour_names.length) {
@@ -583,15 +577,16 @@ odoo.define("terminal.functions.Common", function (require) {
             return Promise.resolve();
         },
 
-        _cmdJSTest: function (module_name, mode) {
-            let mod = module_name || "";
-            if (module_name === "*") {
+        _cmdJSTest: function (kwargs) {
+            let mod = kwargs.module || "";
+            if (kwargs.module === "*") {
                 mod = "";
             }
-            let url = `/web/tests?module=${mod}`;
-            if (mode === "mobile") {
-                url = `/web/tests/mobile?module=${mod}`;
+            let url = "/web/tests";
+            if (kwargs.device === "mobile") {
+                url += "/mobile";
             }
+            url += `?module=${mod}`;
             window.location = url;
             return Promise.resolve();
         },
@@ -626,12 +621,12 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdUserHasGroups: function (groups) {
+        _cmdUserHasGroups: function (kwargs) {
             return rpc
                 .query({
                     method: "user_has_groups",
                     model: "res.users",
-                    args: [groups],
+                    args: [kwargs.group],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
@@ -640,11 +635,11 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdLoginAs: function (database, login_name, pass) {
-            let db = database;
-            let login = login_name;
-            let passwd = pass || false;
-            if (login[0] === "-" && !passwd) {
+        _cmdLoginAs: function (kwargs) {
+            let db = kwargs.database;
+            let login = kwargs.user;
+            let passwd = kwargs.password || false;
+            if (login[0] === "#" && !passwd) {
                 login = login.substr(1);
                 passwd = login;
             }
@@ -692,29 +687,29 @@ odoo.define("terminal.functions.Common", function (require) {
             }
         },
 
-        _cmdLongpolling: function (operation, name) {
+        _cmdLongpolling: function (kwargs) {
             if (!this._longpolling) {
                 return Promise.reject(
                     "Can't use longpolling, 'bus' module is not installed"
                 );
             }
 
-            if (typeof operation === "undefined") {
+            if (typeof kwargs.operation === "undefined") {
                 this.screen.print(this._longpolling.isVerbose() || "off");
-            } else if (operation === "verbose") {
+            } else if (kwargs.operation === "verbose") {
                 this._longpolling.setVerbose(true);
                 this.screen.print("Now long-polling is in verbose mode.");
-            } else if (operation === "off") {
+            } else if (kwargs.operation === "off") {
                 this._longpolling.setVerbose(false);
                 this.screen.print("Now long-polling verbose mode is disabled");
-            } else if (operation === "add_channel") {
-                this._longPollingAddChannel(name);
-            } else if (operation === "del_channel") {
-                this._longPollingDelChannel(name);
-            } else if (operation === "start") {
+            } else if (kwargs.operation === "add_channel") {
+                this._longPollingAddChannel(kwargs.param);
+            } else if (kwargs.operation === "del_channel") {
+                this._longPollingDelChannel(kwargs.param);
+            } else if (kwargs.operation === "start") {
                 this._longpolling.startPoll();
                 this.screen.print("Longpolling started");
-            } else if (operation === "stop") {
+            } else if (kwargs.operation === "stop") {
                 this._longpolling.stopPoll();
                 this.screen.print("Longpolling stopped");
             } else {
@@ -738,45 +733,45 @@ odoo.define("terminal.functions.Common", function (require) {
             return Promise.resolve();
         },
 
-        _cmdContextOperation: function (operation = "read", values = false) {
-            if (operation === "read") {
+        _cmdContextOperation: function (kwargs) {
+            if (kwargs.operation === "read") {
                 this.screen.print(session.user_context);
-            } else if (operation === "set") {
-                session.user_context = values;
+            } else if (kwargs.operation === "set") {
+                session.user_context = kwargs.value;
                 this.screen.print(session.user_context);
-            } else if (operation === "write") {
-                Object.assign(session.user_context, values);
+            } else if (kwargs.operation === "write") {
+                Object.assign(session.user_context, kwargs.value);
                 this.screen.print(session.user_context);
-            } else if (operation === "delete") {
-                if (values in session.user_context) {
-                    delete session.user_context[values];
+            } else if (kwargs.operation === "delete") {
+                if (
+                    Object.prototype.hasOwnProperty.call(
+                        session.user_context,
+                        kwargs.value
+                    )
+                ) {
+                    delete session.user_context[kwargs.value];
                     this.screen.print(session.user_context);
                 } else {
                     this.screen.printError(
                         "The selected key is not present in the terminal context"
                     );
                 }
-            } else {
-                this.screen.printError("Invalid operation");
             }
             return Promise.resolve();
         },
 
-        _cmdSearchModelRecordId: function (model, id, field_names) {
-            let fields = ["display_name"];
-            if (field_names) {
-                fields = field_names === "*" ? false : field_names;
-            }
+        _cmdSearchModelRecordId: function (kwargs) {
+            const fields = kwargs.field[0] === "*" ? false : kwargs.field;
             return rpc
                 .query({
                     method: "search_read",
-                    domain: [["id", "in", id]],
+                    domain: [["id", "in", kwargs.id]],
                     fields: fields,
-                    model: model,
+                    model: kwargs.model,
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
-                    this.screen.printRecords(model, result);
+                    this.screen.printRecords(kwargs.model, result);
                     return result;
                 });
         },
@@ -813,37 +808,34 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdCheckModelAccess: function (model, operation) {
+        _cmdCheckModelAccess: function (kwargs) {
             return rpc
                 .query({
                     method: "check_access_rights",
-                    model: model,
-                    args: [operation, false],
+                    model: kwargs.model,
+                    args: [kwargs.operation, false],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
                     if (result) {
                         this.screen.print(
-                            `You have access rights for '${operation}' on ${model}`
+                            `You have access rights for '${kwargs.operation}' on ${kwargs.model}`
                         );
                     } else {
                         this.screen.print(
-                            `You can't '${operation}' on ${model}`
+                            `You can't '${kwargs.operation}' on ${kwargs.model}`
                         );
                     }
                     return result;
                 });
         },
 
-        _cmdCheckFieldAccess: function (model, field_names = false) {
-            let fields = false;
-            if (field_names) {
-                fields = field_names === "*" ? false : field_names;
-            }
+        _cmdCheckFieldAccess: function (kwargs) {
+            const fields = kwargs.field[0] === "*" ? false : kwargs.field;
             return rpc
                 .query({
                     method: "fields_get",
-                    model: model,
+                    model: kwargs.model,
                     args: [fields],
                     kwargs: {context: this._getContext()},
                 })
@@ -924,15 +916,15 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdSetDebugMode: function (mode) {
-            if (mode === 0) {
+        _cmdSetDebugMode: function (kwargs) {
+            if (kwargs.mode === 0) {
                 this.screen.print(
                     "Debug mode <strong>disabled</strong>. Reloading page..."
                 );
                 const qs = $.deparam.querystring();
                 delete qs.debug;
                 window.location.search = "?" + $.param(qs);
-            } else if (mode === 1) {
+            } else if (kwargs.mode === 1) {
                 this.screen.print(
                     "Debug mode <strong>enabled</strong>. Reloading page..."
                 );
@@ -940,7 +932,7 @@ odoo.define("terminal.functions.Common", function (require) {
                     window.location.href,
                     "debug=1"
                 );
-            } else if (mode === 2) {
+            } else if (kwargs.mode === 2) {
                 this.screen.print(
                     "Debug mode with assets <strong>enabled</strong>. " +
                         "Reloading page..."
@@ -970,8 +962,8 @@ odoo.define("terminal.functions.Common", function (require) {
             });
         },
 
-        _cmdUpgradeModule: function (module_name) {
-            return this._searchModule(module_name).then((result) => {
+        _cmdUpgradeModule: function (kwargs) {
+            return this._searchModule(kwargs.module).then((result) => {
                 if (result.length) {
                     rpc.query({
                         method: "button_immediate_upgrade",
@@ -980,25 +972,25 @@ odoo.define("terminal.functions.Common", function (require) {
                     }).then(
                         () => {
                             this.screen.print(
-                                `'${module_name}' module successfully upgraded`
+                                `'${kwargs.module}' module successfully upgraded`
                             );
                         },
                         () => {
                             this.screen.printError(
-                                `Can't upgrade '${module_name}' module`
+                                `Can't upgrade '${kwargs.module}' module`
                             );
                         }
                     );
                 } else {
                     this.screen.printError(
-                        `'${module_name}' module doesn't exists`
+                        `'${kwargs.module}' module doesn't exists`
                     );
                 }
             });
         },
 
-        _cmdInstallModule: function (module_name) {
-            return this._searchModule(module_name).then((result) => {
+        _cmdInstallModule: function (kwargs) {
+            return this._searchModule(kwargs.module).then((result) => {
                 if (result.length) {
                     rpc.query({
                         method: "button_immediate_install",
@@ -1007,25 +999,25 @@ odoo.define("terminal.functions.Common", function (require) {
                     }).then(
                         () => {
                             this.screen.print(
-                                `'${module_name}' module successfully installed`
+                                `'${kwargs.module}' module successfully installed`
                             );
                         },
                         () => {
                             this.screen.printError(
-                                `Can't install '${module_name}' module`
+                                `Can't install '${kwargs.module}' module`
                             );
                         }
                     );
                 } else {
                     this.screen.printError(
-                        `'${module_name}' module doesn't exists`
+                        `'${kwargs.module}' module doesn't exists`
                     );
                 }
             });
         },
 
-        _cmdUninstallModule: function (module_name) {
-            return this._searchModule(module_name).then((result) => {
+        _cmdUninstallModule: function (kwargs) {
+            return this._searchModule(kwargs.module).then((result) => {
                 if (result.length) {
                     rpc.query({
                         method: "button_immediate_uninstall",
@@ -1034,33 +1026,33 @@ odoo.define("terminal.functions.Common", function (require) {
                     }).then(
                         () => {
                             this.screen.print(
-                                `'${module_name}' module successfully uninstalled`
+                                `'${kwargs.module}' module successfully uninstalled`
                             );
                         },
                         () => {
                             this.screen.printError(
-                                `Can't uninstall '${module_name}' module`
+                                `Can't uninstall '${kwargs.module}' module`
                             );
                         }
                     );
                 } else {
                     this.screen.printError(
-                        `'${module_name}' module doesn't exists`
+                        `'${kwargs.module}' module doesn't exists`
                     );
                 }
             });
         },
 
-        _cmdCallModelMethod: function (model, method, args = [], kwargs = {}) {
-            const pkwargs = kwargs;
+        _cmdCallModelMethod: function (kwargs) {
+            const pkwargs = kwargs.kwarg;
             if (typeof pkwargs.context === "undefined") {
                 pkwargs.context = this._getContext();
             }
             return rpc
                 .query({
-                    method: method,
-                    model: model,
-                    args: args,
+                    method: kwargs.method,
+                    model: kwargs.model,
+                    args: kwargs.arguments,
                     kwargs: pkwargs,
                 })
                 .then((result) => {
@@ -1097,22 +1089,11 @@ odoo.define("terminal.functions.Common", function (require) {
             return res;
         },
 
-        _cmdSearchModelRecord: function (
-            model,
-            field_names,
-            domain = [],
-            limit,
-            offset,
-            order
-        ) {
+        _cmdSearchModelRecord: function (kwargs) {
             const lines_total = this.screen._max_lines - 3;
-            let fields = ["display_name"];
-            if (field_names) {
-                fields = field_names === "*" ? false : field_names;
-            }
+            const fields = kwargs.field[0] === "*" ? false : kwargs.field;
 
-            // Workaround: '--more' is a special model name to handle print the rest of the previous call result
-            if (model === "--more") {
+            if (kwargs.more) {
                 const buff = this._buffer[this.__meta.name];
                 if (!buff || !buff.data.length) {
                     this.screen.printError(
@@ -1135,12 +1116,12 @@ odoo.define("terminal.functions.Common", function (require) {
             return rpc
                 .query({
                     method: "search_read",
-                    domain: domain,
+                    domain: kwargs.domain,
                     fields: fields,
-                    model: model,
-                    limit: limit,
-                    offset: offset,
-                    orderBy: this._deserializeSort(order),
+                    model: kwargs.model,
+                    limit: kwargs.limit,
+                    offset: kwargs.offset,
+                    orderBy: this._deserializeSort(kwargs.order),
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
@@ -1148,12 +1129,12 @@ odoo.define("terminal.functions.Common", function (require) {
                     let sresult = result;
                     if (need_truncate) {
                         this._buffer[this.__meta.name] = {
-                            model: model,
+                            model: kwargs.model,
                             data: sresult.slice(lines_total),
                         };
                         sresult = sresult.slice(0, lines_total);
                     }
-                    this.screen.printRecords(model, sresult);
+                    this.screen.printRecords(kwargs.model, sresult);
                     if (need_truncate) {
                         this.screen.printError(
                             `<strong class='text-warning'>Result truncated!</strong> The query is too big to be displayed entirely. Use '<strong class='o_terminal_click o_terminal_cmd' data-cmd='search --more'>search --more</strong>' to print the rest of the results (${
@@ -1166,11 +1147,11 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdCreateModelRecord: function (model, values) {
-            if (typeof values === "undefined") {
+        _cmdCreateModelRecord: function (kwargs) {
+            if (typeof kwargs.value === "undefined") {
                 return this.do_action({
                     type: "ir.actions.act_window",
-                    res_model: model,
+                    res_model: kwargs.model,
                     views: [[false, "form"]],
                     target: "current",
                 }).then(() => {
@@ -1180,14 +1161,14 @@ odoo.define("terminal.functions.Common", function (require) {
             return rpc
                 .query({
                     method: "create",
-                    model: model,
-                    args: [values],
+                    model: kwargs.model,
+                    args: [kwargs.value],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
                     this.screen.print(
                         this._templates.render("RECORD_CREATED", {
-                            model: model,
+                            model: kwargs.model,
                             new_id: result,
                         })
                     );
@@ -1195,44 +1176,48 @@ odoo.define("terminal.functions.Common", function (require) {
                 });
         },
 
-        _cmdUnlinkModelRecord: function (model, id) {
+        _cmdUnlinkModelRecord: function (kwargs) {
             return rpc
                 .query({
                     method: "unlink",
-                    model: model,
-                    args: [id],
+                    model: kwargs.model,
+                    args: [kwargs.id],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
-                    this.screen.print(`${model} record deleted successfully`);
+                    this.screen.print(
+                        `${kwargs.model} record deleted successfully`
+                    );
                     return result;
                 });
         },
 
-        _cmdWriteModelRecord: function (model, id, values) {
+        _cmdWriteModelRecord: function (kwargs) {
             return rpc
                 .query({
                     method: "write",
-                    model: model,
-                    args: [id, values],
+                    model: kwargs.model,
+                    args: [kwargs.id, kwargs.value],
                     kwargs: {context: this._getContext()},
                 })
                 .then((result) => {
-                    this.screen.print(`${model} record updated successfully`);
+                    this.screen.print(
+                        `${kwargs.model} record updated successfully`
+                    );
                     return result;
                 });
         },
 
-        _cmdCallAction: function (action) {
-            let saction = action;
-            if (this._parameterReader._validateJson(action)) {
-                saction = this._parameterReader._formatJson(action);
+        _cmdCallAction: function (kwargs) {
+            let saction = kwargs.action;
+            if (this._parameterReader._validateJson(kwargs.action)) {
+                saction = this._parameterReader._formatJson(kwargs.action);
             }
             return this.do_action(saction);
         },
 
-        _cmdPostData: function (url, data) {
-            return ajax.post(url, data).then((result) => {
+        _cmdPostData: function (kwargs) {
+            return ajax.post(kwargs.endpoint, kwargs.data).then((result) => {
                 this.screen.print(result);
             });
         },

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -360,7 +360,7 @@ odoo.define("terminal.functions.Common", function (require) {
                         }
 
                         // Get action to export
-                        const action = await rpc.query({
+                        await rpc.query({
                             method: "act_getfile",
                             model: "base.language.export",
                             args: [[wizard_id]],
@@ -377,7 +377,7 @@ odoo.define("terminal.functions.Common", function (require) {
                         });
 
                         // Get file
-                        await Utils.getContent(
+                        const content_def = Utils.getContent(
                             {
                                 model: "base.language.export",
                                 id: wizard_id,
@@ -388,7 +388,7 @@ odoo.define("terminal.functions.Common", function (require) {
                             this.printError
                         );
 
-                        return resolve(action);
+                        return resolve(content_def);
                     } else if (kwargs.operation === "import") {
                         if (is_empty_args) {
                             return resolve(
@@ -409,6 +409,7 @@ odoo.define("terminal.functions.Common", function (require) {
                         }
                         // Get file content
                         const file64 = await Utils.file2Base64();
+
                         // Create wizard record
                         const wizard_id = await rpc.query({
                             method: "create",

--- a/odoo/js/functions/common.js
+++ b/odoo/js/functions/common.js
@@ -1209,11 +1209,7 @@ odoo.define("terminal.functions.Common", function (require) {
         },
 
         _cmdCallAction: function (kwargs) {
-            let saction = kwargs.action;
-            if (this._parameterReader._validateJson(kwargs.action)) {
-                saction = this._parameterReader._formatJson(kwargs.action);
-            }
-            return this.do_action(saction);
+            return this.do_action(kwargs.action);
         },
 
         _cmdPostData: function (kwargs) {

--- a/odoo/js/functions/core.js
+++ b/odoo/js/functions/core.js
@@ -17,46 +17,44 @@ odoo.define("terminal.functions.Core", function (require) {
                 detail:
                     "Show commands and a quick definition.<br/>- " +
                     "<> ~> Required Parameter<br/>- [] ~> Optional Parameter",
-                syntax: "[STRING: COMMAND]",
-                args: "?s",
-                example: "search",
+                args: ["s::c:cmd::0::The command to consult"],
+                example: "-c search",
             });
             this.registerCommand("clear", {
-                definition: "Clean terminal section (screen by default)",
+                definition: "Clean terminal section",
                 callback: this._cmdClear,
-                detail: "Available sections: screen (default), history.",
-                syntax: "[STRING: SECTION]",
-                args: "?s",
-                example: "history",
+                detail: "Clean the selected section",
+                args: [
+                    "s::s:section::0::The section to clear<br/>- screen: Clean the screen<br/>- history: Clean the command history::screen::screen:history",
+                ],
+                example: "-s history",
             });
             this.registerCommand("print", {
                 definition: "Print a message",
                 callback: this._cmdPrintText,
                 detail: "Eval parameters and print the result.",
-                syntax: "<STRING: MSG>",
-                args: "",
+                args: ["s::m:msg::1::The message to print"],
                 aliases: ["echo"],
-                example: "This is a example",
+                example: "-m 'This is a example'",
             });
             this.registerCommand("load", {
                 definition: "Load external resource",
                 callback: this._cmdLoadResource,
                 detail: "Load external source (javascript & css)",
-                syntax: "<STRING: URL>",
-                args: "s",
-                example: "https://example.com/libs/term_extra.js",
+                args: ["s::u:url::1::The URL of the asset"],
+                example: "-u https://example.com/libs/term_extra.js",
             });
             this.registerCommand("context_term", {
                 definition: "Operations over terminal context dictionary",
                 callback: this._cmdTerminalContextOperation,
                 detail:
                     "Operations over terminal context dictionary. " +
-                    "This context only affects to the terminal operations." +
-                    "<br>[OPERATION] can be 'read', 'write', 'set' or 'delete'. " +
-                    "By default is 'read'. ",
-                syntax: '[STRING: OPERATION] "[DICT: VALUES]/[STRING: KEY]" ',
-                args: "?sj",
-                example: "write \"{'the_example': 1}\"",
+                    "This context only affects to the terminal operations.",
+                args: [
+                    "s::o:operation::0::The operation to do::read::read:write:set:delete",
+                    "j::v:value::0::The URL of the asset::false",
+                ],
+                example: "-o write -v \"{'the_example': 1}\"",
             });
             this.registerCommand("alias", {
                 definition: "Create aliases",
@@ -69,11 +67,13 @@ odoo.define("terminal.functions.Core", function (require) {
                     "Don't use sensible data if you are using a shared " +
                     "computer." +
                     "<br><br>Can use positional parameters ($1,$2,$3,$N...)",
-                syntax: "[STRING: ALIAS] [STRING: DEFINITION]",
-                args: "?s*",
+                args: [
+                    "s::n:name::0::The name of the alias",
+                    "s::c:cmd::0::The command to run",
+                ],
                 sanitized: false,
                 generators: false,
-                example: 'myalias print "Hello, $1!"',
+                example: "-n myalias -c \"print 'Hello, $1!'\"",
             });
             this.registerCommand("quit", {
                 definition: "Close terminal",
@@ -85,21 +85,19 @@ odoo.define("terminal.functions.Core", function (require) {
                     "Exports the command result to a browser console variable",
                 callback: this._cmdExport,
                 detail: "Exports the command result to a browser console variable.",
-                syntax: "<STRING: COMMAND>",
-                args: "*",
+                args: ["s::c:cmd::1::The command to run and export the result"],
                 sanitized: false,
                 generators: false,
-                example: "search res.partner",
+                example: "-c 'search res.partner'",
             });
             this.registerCommand("exportfile", {
                 definition: "Exports the command result to a text/json file",
                 callback: this._cmdExportFile,
                 detail: "Exports the command result to a text/json file.",
-                syntax: "<STRING: COMMAND>",
-                args: "*",
+                args: ["s::c:cmd::1::The command to run and export the result"],
                 sanitized: false,
                 generators: false,
-                example: "search res.partner",
+                example: "-c 'search res.partner'",
             });
             this.registerCommand("chrono", {
                 definition: "Print the time expended executing a command",
@@ -108,38 +106,38 @@ odoo.define("terminal.functions.Core", function (require) {
                     "Print the elapsed time in seconds to execute a command. " +
                     "<br/>Notice that this time includes the time to format the result!",
                 syntax: "<STRING: COMMAND>",
-                args: "*",
+                args: ["s::c:cmd::1::The command to run"],
                 sanitized: false,
                 generators: false,
-                example: "search res.partner",
+                example: "-c 'search res.partner'",
             });
             this.registerCommand("repeat", {
                 definition: "Repeat a command N times",
                 callback: this._cmdRepeat,
                 detail: "Repeat a command N times.",
-                syntax: "<INT: TIMES> <STRING: COMMAND>",
-                args: "i*",
+                args: [
+                    "i::t:times::1::Times to run",
+                    "s::c:cmd::1::The command to run",
+                ],
                 sanitized: false,
                 generators: false,
                 example:
-                    "20 create res.partner \"{'name': 'Example Partner #$INTITER'}\"",
+                    "-t 20 -c \"create res.partner \\\"{'name': 'Example Partner #$INTITER'}\\\"\"",
             });
             this.registerCommand("mute", {
                 definition: "Only prints errors",
                 callback: this._cmdMute,
                 detail: "Print to screen is a really slow task, you can improve performance if only prints errors.",
-                syntax: "<STRING: COMMAND>",
-                args: "*",
+                args: ["s::c:cmd::1::The command to run"],
                 sanitized: false,
                 generators: false,
                 example:
-                    "repeat 20 create res.partner \"{'name': 'Example Partner #$INTITER'}\"",
+                    "-c \"repeat 20 create res.partner \\\"{'name': 'Example Partner #$INTITER'}\\\"\"",
             });
             this.registerCommand("jobs", {
                 definition: "Display running jobs",
                 callback: this._cmdJobs,
                 detail: "Display running jobs",
-                syntax: "",
                 args: "",
                 sanitized: false,
                 generators: false,
@@ -167,16 +165,65 @@ odoo.define("terminal.functions.Core", function (require) {
         },
 
         _printHelpDetailed: function (cmd, cmd_def) {
-            this.screen.print(cmd_def.detail);
+            this.screen.eprint("NAME");
+            this.screen.print(
+                `<div class="terminal-info-section">${cmd} - ${cmd_def.definition}</div>`
+            );
             this.screen.print(" ");
-            this.screen.eprint(`Syntax: ${cmd} ${cmd_def.syntax}`);
+            this.screen.eprint("DESCRIPTION");
+            this.screen.print(
+                `<div class="terminal-info-section">${cmd_def.detail}</div>`
+            );
+            // Create arguments text
+            this.screen.print(" ");
+            this.screen.eprint("ARGUMENTS");
+            const args = [];
+            let arg_info_str = "";
+            for (const arg of cmd_def.args) {
+                const arg_info = this._parameterReader.getArgumentInfo(arg);
+                const lnames = [
+                    `-${arg_info.names.short}`,
+                    `--${arg_info.names.long}`,
+                ];
+                const arg_symbols = arg_info.is_required
+                    ? ["<", ">"]
+                    : ["[", "]"];
+                arg_info_str += `${arg_symbols[0]}${lnames.join(
+                    ", "
+                )} [${this._parameterReader.getHumanType(arg_info.type)}`;
+                if (_.isEmpty(arg_info.strict_values)) {
+                    arg_info_str += `]${arg_symbols[1]}`;
+                } else {
+                    arg_info_str += `(${arg_info.strict_values.join("|")})]${
+                        arg_symbols[1]
+                    }`;
+                }
+                if (typeof arg_info.default_value !== "undefined") {
+                    arg_info_str += ` (default is ${
+                        arg_info.type[0] === "l"
+                            ? arg_info.default_value.join(",")
+                            : arg_info.type[0] === "j"
+                            ? JSON.stringify(arg_info.default_value)
+                            : arg_info.default_value
+                    })`;
+                }
+                arg_info_str += `<div class="terminal-info-description">${arg_info.description}</div>`;
+                arg_info_str += "<br/>";
+            }
+            this.screen.print(
+                `<div class="terminal-info-section">${arg_info_str}</div>`
+            );
+            this.screen.print(args);
             if (cmd_def.example) {
-                this.screen.eprint(`Example: ${cmd} ${cmd_def.example}`);
+                this.screen.eprint("EXAMPLE");
+                this.screen.print(
+                    `<div class="terminal-info-section">${cmd} ${cmd_def.example}</div>`
+                );
             }
         },
 
-        _cmdPrintHelp: function (cmd) {
-            if (typeof cmd === "undefined") {
+        _cmdPrintHelp: function (kwargs) {
+            if (typeof kwargs.cmd === "undefined") {
                 const sorted_cmd_keys = _.keys(this._registeredCmds).sort();
                 const sorted_keys_len = sorted_cmd_keys.length;
                 for (let x = 0; x < sorted_keys_len; ++x) {
@@ -184,11 +231,19 @@ odoo.define("terminal.functions.Core", function (require) {
                     this._printHelpSimple(_cmd, this._registeredCmds[_cmd]);
                 }
             } else if (
-                Object.prototype.hasOwnProperty.call(this._registeredCmds, cmd)
+                Object.prototype.hasOwnProperty.call(
+                    this._registeredCmds,
+                    kwargs.cmd
+                )
             ) {
-                this._printHelpDetailed(cmd, this._registeredCmds[cmd]);
+                this._printHelpDetailed(
+                    kwargs.cmd,
+                    this._registeredCmds[kwargs.cmd]
+                );
             } else {
-                const [ncmd, cmd_def] = this._searchCommandDefByAlias(cmd);
+                const [ncmd, cmd_def] = this._searchCommandDefByAlias(
+                    kwargs.cmd
+                );
                 if (cmd_def) {
                     this.screen.print(
                         this._templates.render("DEPRECATED_COMMAND", {
@@ -197,14 +252,16 @@ odoo.define("terminal.functions.Core", function (require) {
                     );
                     this._printHelpDetailed(ncmd, this._registeredCmds[ncmd]);
                 } else {
-                    this.screen.printError(`'${cmd}' command doesn't exists`);
+                    this.screen.printError(
+                        `'${kwargs.cmd}' command doesn't exists`
+                    );
                 }
             }
             return Promise.resolve();
         },
 
-        _cmdClear: function (section) {
-            if (section === "history") {
+        _cmdClear: function (kwargs) {
+            if (kwargs.section === "history") {
                 this.cleanInputHistory();
             } else {
                 this.screen.clean();
@@ -212,14 +269,13 @@ odoo.define("terminal.functions.Core", function (require) {
             return Promise.resolve();
         },
 
-        _cmdPrintText: function (...text) {
-            const to_print = this._parameterReader.stringify(text);
-            this.screen.print(to_print);
-            return Promise.resolve(to_print);
+        _cmdPrintText: function (kwargs) {
+            this.screen.print(kwargs.msg);
+            return Promise.resolve(kwargs.msg);
         },
 
-        _cmdLoadResource: function (url) {
-            const inURL = new URL(url);
+        _cmdLoadResource: function (kwargs) {
+            const inURL = new URL(kwargs.url);
             const pathname = inURL.pathname.toLowerCase();
             if (pathname.endsWith(".js")) {
                 return $.getScript(inURL.href);
@@ -235,37 +291,37 @@ odoo.define("terminal.functions.Core", function (require) {
             return Promise.resolve();
         },
 
-        _cmdTerminalContextOperation: function (
-            operation = "read",
-            values = false
-        ) {
-            if (operation === "read") {
+        _cmdTerminalContextOperation: function (kwargs) {
+            if (kwargs.operation === "read") {
                 this.screen.print(this._userContext);
-            } else if (operation === "set") {
-                this._userContext = values;
+            } else if (kwargs.operation === "set") {
+                this._userContext = kwargs.value;
                 this.screen.print(this._userContext);
-            } else if (operation === "write") {
-                Object.assign(this._userContext, values);
+            } else if (kwargs.operation === "write") {
+                Object.assign(this._userContext, kwargs.value);
                 this.screen.print(this._userContext);
-            } else if (operation === "delete") {
-                if (values in this._userContext) {
-                    delete this._userContext[values];
+            } else if (kwargs.operation === "delete") {
+                if (
+                    Object.prototype.hasOwnProperty.call(
+                        this._userContext,
+                        kwargs.value
+                    )
+                ) {
+                    delete this._userContext[kwargs.value];
                     this.screen.print(this._userContext);
                 } else {
                     this.screen.printError(
                         "The selected key is not present in the terminal context"
                     );
                 }
-            } else {
-                this.screen.printError("Invalid operation");
             }
             return Promise.resolve();
         },
 
-        _cmdAlias: function (name = false, ...defcall) {
+        _cmdAlias: function (kwargs) {
             const aliases =
                 this._storageLocal.getItem("terminal_aliases") || {};
-            if (!name) {
+            if (!kwargs.name) {
                 if (_.isEmpty(aliases)) {
                     this.screen.print("No aliases defined.");
                 } else {
@@ -275,14 +331,19 @@ odoo.define("terminal.functions.Core", function (require) {
                         );
                     }
                 }
-            } else if (name in this._registeredCmds) {
+            } else if (
+                Object.prototype.hasOwnProperty.call(
+                    this._registeredCmds,
+                    kwargs.name
+                )
+            ) {
                 this.screen.printError("Invalid alias name");
             } else {
-                if (_.some(defcall)) {
-                    aliases[name] = this._parameterReader.stringify(defcall);
+                if (_.some(kwargs.cmd)) {
+                    aliases[kwargs.name] = kwargs.cmd;
                     this.screen.print("Alias created successfully");
                 } else {
-                    delete aliases[name];
+                    delete aliases[kwargs.name];
                     this.screen.print("Alias removed successfully");
                 }
                 this._storageLocal.setItem("terminal_aliases", aliases, (err) =>
@@ -297,25 +358,16 @@ odoo.define("terminal.functions.Core", function (require) {
             return Promise.resolve();
         },
 
-        _validateDefCommand: function (defcall) {
-            if (!_.some(defcall)) {
-                return [false, false];
-            }
-            const cmd = this._parameterReader.stringify(defcall);
-            return this.validateCommand(cmd);
-        },
-
-        _cmdExport: function (...defcall) {
+        _cmdExport: function (kwargs) {
             return new Promise(async (resolve, reject) => {
                 try {
                     // eslint-disable-next-line
-                    const [cmd, cmd_name] =
-                        this._validateDefCommand(defcall)[1];
+                    const [cmd, cmd_name] = this.validateCommand(kwargs.cmd)[1];
                     if (!cmd_name) {
                         return reject("Need a valid command to execute!");
                     }
                     const varname = _.uniqueId("term");
-                    window[varname] = await this._cmdMute(...defcall);
+                    window[varname] = await this._cmdMute({cmd: kwargs.cmd});
                     this.screen.print(
                         `Command result exported! now you can use '${varname}' variable in the browser console`
                     );
@@ -326,17 +378,16 @@ odoo.define("terminal.functions.Core", function (require) {
             });
         },
 
-        _cmdExportFile: function (...defcall) {
+        _cmdExportFile: function (kwargs) {
             return new Promise(async (resolve, reject) => {
                 try {
                     // eslint-disable-next-line
-                    const [cmd, cmd_name] =
-                        this._validateDefCommand(defcall)[1];
+                    const [cmd, cmd_name] = this.validateCommand(kwargs.cmd)[1];
                     if (!cmd_name) {
                         return reject("Need a valid command to execute!");
                     }
                     const filename = `${cmd_name}_${new Date().getTime()}.json`;
-                    const result = await this._cmdMute(...defcall);
+                    const result = await this._cmdMute({cmd: kwargs.cmd});
                     Utils.save2File(
                         filename,
                         "text/json",
@@ -352,10 +403,10 @@ odoo.define("terminal.functions.Core", function (require) {
             });
         },
 
-        _cmdChrono: function (...defcall) {
+        _cmdChrono: function (kwargs) {
             return new Promise(async (resolve, reject) => {
                 try {
-                    const [cmd, cmd_name] = this._validateDefCommand(defcall);
+                    const [cmd, cmd_name] = this.validateCommand(kwargs.cmd);
                     if (!cmd_name) {
                         return reject("Need a valid command to execute!");
                     }
@@ -375,12 +426,12 @@ odoo.define("terminal.functions.Core", function (require) {
             });
         },
 
-        _cmdRepeat: function (times, ...defcall) {
+        _cmdRepeat: function (kwargs) {
             return new Promise((resolve, reject) => {
-                if (times < 0) {
+                if (kwargs.times < 0) {
                     return reject("'Times' parameter must be positive");
                 }
-                const [cmd, cmd_name] = this._validateDefCommand(defcall);
+                const [cmd, cmd_name] = this.validateCommand(kwargs.cmd);
                 if (!cmd_name) {
                     return reject("Need a valid command to execute!");
                 }
@@ -388,7 +439,7 @@ odoo.define("terminal.functions.Core", function (require) {
                 const do_repeat = (rtimes) => {
                     if (!rtimes) {
                         this.screen.print(
-                            `<i>** Repeat finsihed: command called ${times} times</i>`
+                            `<i>** Repeat finsihed: command called ${kwargs.times} times</i>`
                         );
                         return resolve();
                     }
@@ -397,12 +448,12 @@ odoo.define("terminal.functions.Core", function (require) {
                         do_repeat(rtimes - 1)
                     );
                 };
-                do_repeat(times);
+                do_repeat(kwargs.times);
             });
         },
 
-        _cmdMute: function (...defcall) {
-            const [cmd, cmd_name] = this._validateDefCommand(defcall);
+        _cmdMute: function (kwargs) {
+            const [cmd, cmd_name] = this.validateCommand(kwargs.cmd);
             if (!cmd_name) {
                 return Promise.reject("Need a valid command to execute!");
             }

--- a/odoo/js/functions/core.js
+++ b/odoo/js/functions/core.js
@@ -55,7 +55,7 @@ odoo.define("terminal.functions.Core", function (require) {
                     "<br>[OPERATION] can be 'read', 'write', 'set' or 'delete'. " +
                     "By default is 'read'. ",
                 syntax: '[STRING: OPERATION] "[DICT: VALUES]/[STRING: KEY]" ',
-                args: "?ss",
+                args: "?sj",
                 example: "write \"{'the_example': 1}\"",
             });
             this.registerCommand("alias", {
@@ -84,8 +84,7 @@ odoo.define("terminal.functions.Core", function (require) {
                 definition:
                     "Exports the command result to a browser console variable",
                 callback: this._cmdExport,
-                detail:
-                    "Exports the command result to a browser console variable.",
+                detail: "Exports the command result to a browser console variable.",
                 syntax: "<STRING: COMMAND>",
                 args: "*",
                 sanitized: false,
@@ -128,8 +127,7 @@ odoo.define("terminal.functions.Core", function (require) {
             this.registerCommand("mute", {
                 definition: "Only prints errors",
                 callback: this._cmdMute,
-                detail:
-                    "Print to screen is a really slow task, you can improve performance if only prints errors.",
+                detail: "Print to screen is a really slow task, you can improve performance if only prints errors.",
                 syntax: "<STRING: COMMAND>",
                 args: "*",
                 sanitized: false,
@@ -239,15 +237,15 @@ odoo.define("terminal.functions.Core", function (require) {
 
         _cmdTerminalContextOperation: function (
             operation = "read",
-            values = "false"
+            values = false
         ) {
             if (operation === "read") {
                 this.screen.print(this._userContext);
             } else if (operation === "set") {
-                this._userContext = JSON.parse(values);
+                this._userContext = values;
                 this.screen.print(this._userContext);
             } else if (operation === "write") {
-                Object.assign(this._userContext, JSON.parse(values));
+                Object.assign(this._userContext, values);
                 this.screen.print(this._userContext);
             } else if (operation === "delete") {
                 if (values in this._userContext) {
@@ -311,9 +309,8 @@ odoo.define("terminal.functions.Core", function (require) {
             return new Promise(async (resolve, reject) => {
                 try {
                     // eslint-disable-next-line
-                    const [cmd, cmd_name] = this._validateDefCommand(
-                        defcall
-                    )[1];
+                    const [cmd, cmd_name] =
+                        this._validateDefCommand(defcall)[1];
                     if (!cmd_name) {
                         return reject("Need a valid command to execute!");
                     }
@@ -333,9 +330,8 @@ odoo.define("terminal.functions.Core", function (require) {
             return new Promise(async (resolve, reject) => {
                 try {
                     // eslint-disable-next-line
-                    const [cmd, cmd_name] = this._validateDefCommand(
-                        defcall
-                    )[1];
+                    const [cmd, cmd_name] =
+                        this._validateDefCommand(defcall)[1];
                     if (!cmd_name) {
                         return reject("Need a valid command to execute!");
                     }

--- a/odoo/js/functions/core.js
+++ b/odoo/js/functions/core.js
@@ -460,7 +460,7 @@ odoo.define("terminal.functions.Core", function (require) {
                     jobs,
                     (item) =>
                         `${item.scmd.cmd} <small><i>${
-                            item.scmd.rawParams
+                            item.scmd.cmdRaw
                         }</i></small> ${
                             item.healthy
                                 ? ""

--- a/odoo/js/functions/core.js
+++ b/odoo/js/functions/core.js
@@ -52,9 +52,9 @@ odoo.define("terminal.functions.Core", function (require) {
                 detail:
                     "Operations over terminal context dictionary. " +
                     "This context only affects to the terminal operations." +
-                    "<br>[OPERATION] can be 'read', 'write' or 'set'. " +
+                    "<br>[OPERATION] can be 'read', 'write', 'set' or 'delete'. " +
                     "By default is 'read'. ",
-                syntax: '[STRING: OPERATION] "[DICT: VALUES]" ',
+                syntax: '[STRING: OPERATION] "[DICT: VALUES]/[STRING: KEY]" ',
                 args: "?ss",
                 example: "write \"{'the_example': 1}\"",
             });
@@ -249,6 +249,15 @@ odoo.define("terminal.functions.Core", function (require) {
             } else if (operation === "write") {
                 Object.assign(this._userContext, JSON.parse(values));
                 this.screen.print(this._userContext);
+            } else if (operation === "delete") {
+                if (values in this._userContext) {
+                    delete this._userContext[values];
+                    this.screen.print(this._userContext);
+                } else {
+                    this.screen.printError(
+                        "The selected key is not present in the terminal context"
+                    );
+                }
             } else {
                 this.screen.printError("Invalid operation");
             }

--- a/odoo/js/functions/fuzz.js
+++ b/odoo/js/functions/fuzz.js
@@ -1,4 +1,3 @@
-/* global py */
 // Copyright 2020 Alexandre Díaz <dev@redneboa.es>
 // License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -47,9 +46,10 @@ odoo.define("terminal.functions.Fuzz", function (require) {
 
         process: function (field, omitted_values) {
             const hasWidgetGenerator = field.widget in this._generators;
-            const callback = this._generators[
-                hasWidgetGenerator ? field.widget : field.type
-            ];
+            const callback =
+                this._generators[
+                    hasWidgetGenerator ? field.widget : field.type
+                ];
             if (callback) {
                 return callback(field, omitted_values);
             }
@@ -239,15 +239,13 @@ odoo.define("terminal.functions.Fuzz", function (require) {
                         this._O2MRequiredStore = {};
                         try {
                             for (let i = 0; i < num_records; ++i) {
-                                const [
-                                    field_def,
-                                    affected_fields,
-                                ] = await this._fillField(
-                                    controller,
-                                    field,
-                                    field_info,
-                                    def_value
-                                );
+                                const [field_def, affected_fields] =
+                                    await this._fillField(
+                                        controller,
+                                        field,
+                                        field_info,
+                                        def_value
+                                    );
                                 processed[field_name] = field_def;
                                 fields_ignored = _.union(
                                     fields_ignored,
@@ -320,9 +318,8 @@ odoo.define("terminal.functions.Fuzz", function (require) {
                         field_info,
                         domain
                     );
-                    changes[
-                        field_info.name
-                    ] = this._fieldValueGenerator.process(gen_field_def);
+                    changes[field_info.name] =
+                        this._fieldValueGenerator.process(gen_field_def);
                     if (def_value) {
                         if (field.type === "many2one") {
                             changes[field_info.name].id = Number(def_value);
@@ -351,7 +348,7 @@ odoo.define("terminal.functions.Fuzz", function (require) {
                 }
                 if (typeof raw_value === "object") {
                     this._term.screen.eprint(
-                        " [o] Writing the new random value:"
+                        ` [o] Writing the new random value:`
                     );
                     this._term.screen.print(
                         this._term.screen._prettyObjectString(raw_value)
@@ -536,18 +533,18 @@ odoo.define("terminal.functions.Fuzz", function (require) {
                         );
                         let omitted_values = null;
                         if (field_info.name in this._O2MRequiredStore) {
-                            omitted_values = this._O2MRequiredStore[
-                                field_info.name
-                            ][field_view_name];
+                            omitted_values =
+                                this._O2MRequiredStore[field_info.name][
+                                    field_view_name
+                                ];
                         }
                         const data = this._fieldValueGenerator.process(
                             gen_field_def,
                             omitted_values
                         );
                         if (data) {
-                            changes[field_info.name].data[
-                                field_view_name
-                            ] = data;
+                            changes[field_info.name].data[field_view_name] =
+                                data;
                             this._processO2MRequiredField(
                                 field_info.name,
                                 field_view_name,
@@ -650,10 +647,8 @@ odoo.define("terminal.functions.Fuzz", function (require) {
                 definition:
                     "Fill a field with a random or given values on the active form",
                 callback: this._cmdFuzzField,
-                detail:
-                    "Fill a field/s with a random or given values on the active form",
-                syntax:
-                    "[LIST: FIELDS] [STRING/INT: VALUE/S] [INT: O2M RECORDS COUNT]",
+                detail: "Fill a field/s with a random or given values on the active form",
+                syntax: "[LIST: FIELDS] [STRING/INT: VALUE/S] [INT: O2M RECORDS COUNT]",
                 args: "ls?-i",
                 example: "order_line \"{'display_type': false}\" 4",
             });
@@ -664,8 +659,8 @@ odoo.define("terminal.functions.Fuzz", function (require) {
             if (typeof ovalues !== "undefined") {
                 ovalues = JSON.parse(values);
             }
-            const controller_stack = this.getParent().action_manager
-                .controllerStack;
+            const controller_stack =
+                this.getParent().action_manager.controllerStack;
             if (!controller_stack.length) {
                 return Promise.reject("Can't detect any controller");
             }
@@ -737,15 +732,13 @@ odoo.define("terminal.functions.Fuzz", function (require) {
                 try {
                     this.screen.eprint("Writing random values...");
                     const fuzz_form = new FuzzForm(this);
-                    const [
-                        processed_fields,
-                        ignored_fields,
-                    ] = await fuzz_form.processFormFields(
-                        form_controller,
-                        fields,
-                        def_values,
-                        o2m_num_records
-                    );
+                    const [processed_fields, ignored_fields] =
+                        await fuzz_form.processFormFields(
+                            form_controller,
+                            fields,
+                            def_values,
+                            o2m_num_records
+                        );
                     const required_count = _.size(
                         _.filter(processed_fields, (field) => field.required)
                     );

--- a/odoo/js/loaders/backend.js
+++ b/odoo/js/loaders/backend.js
@@ -8,6 +8,8 @@ odoo.define("terminal.loaders.Backend", function (require) {
     const Terminal = require("terminal.Terminal");
     const WebClientObj = require("web.web_client");
 
+    const _t = core._t;
+
     // Ensure load resources
     require("terminal.functions.Core");
     require("terminal.functions.Common");
@@ -36,7 +38,7 @@ odoo.define("terminal.loaders.Backend", function (require) {
             );
         } catch (e) {
             console.error(e);
-            console.warn("[OdooTerminal] Can't initialize the terminal!");
+            console.warn(_t("[OdooTerminal] Can't initialize the terminal!"));
         }
     });
 });

--- a/odoo/js/loaders/frontend.js
+++ b/odoo/js/loaders/frontend.js
@@ -8,6 +8,8 @@ odoo.define("terminal.loaders.Frontend", function (require) {
     const core = require("web.core");
     const Terminal = require("terminal.Terminal");
 
+    const _t = core._t;
+
     // Ensure load resources
     require("terminal.functions.Core");
     require("terminal.functions.Common");
@@ -30,7 +32,7 @@ odoo.define("terminal.loaders.Frontend", function (require) {
             );
         } catch (e) {
             console.error(e);
-            console.warn("[OdooTerminal] Can't initialize the terminal!");
+            console.warn(_t("[OdooTerminal] Can't initialize the terminal!"));
         }
     });
 });

--- a/odoo/js/terminal.js
+++ b/odoo/js/terminal.js
@@ -224,6 +224,7 @@ odoo.define("terminal.Terminal", function (require) {
             if (!cmd_def) {
                 return Promise.reject(_t("Need a valid command to execute!"));
             }
+
             const scmd = this._parameterReader.parse(cmd, cmd_def);
             return this._processCommandJob.call(context || this, scmd, cmd_def);
         },
@@ -245,17 +246,19 @@ odoo.define("terminal.Terminal", function (require) {
                 let cmd_def = this._registeredCmds[cmd_name];
                 let scmd = {};
 
-                // Stop execution if the command doesn't exists
-                if (!cmd_def) {
-                    [, cmd_def] = this._searchCommandDefByAlias(cmd_name);
-                    if (!cmd_def) {
-                        return resolve(
-                            this._alternativeExecuteCommand(cmd, store)
-                        );
-                    }
-                }
-
                 try {
+                    // Stop execution if the command doesn't exists
+                    if (!cmd_def) {
+                        [, cmd_def] = this._searchCommandDefByAlias(cmd_name);
+                        if (!cmd_def) {
+                            const cmd_res = this._alternativeExecuteCommand(
+                                cmd,
+                                store
+                            );
+                            return resolve(cmd_res);
+                        }
+                    }
+
                     this._parameterReader.resetStores();
                     scmd = this._parameterReader.parse(cmd, cmd_def);
                 } catch (err) {
@@ -263,7 +266,7 @@ odoo.define("terminal.Terminal", function (require) {
                     this.screen.printError(
                         `<span class='o_terminal_click ` +
                             `o_terminal_cmd' data-cmd='help ${cmd_name}'>` +
-                            `${err.message}!</span>`
+                            `${err}!</span>`
                     );
                     if (store) {
                         this._storeUserInput(cmd_raw);

--- a/odoo/js/terminal.js
+++ b/odoo/js/terminal.js
@@ -190,8 +190,7 @@ odoo.define("terminal.Terminal", function (require) {
                     detail: _lt(
                         "This command hasn't a properly detailed information"
                     ),
-                    syntax: "Unknown",
-                    args: "",
+                    args: null,
                     secured: false,
                     aliases: [],
                     sanitized: true,
@@ -397,7 +396,7 @@ odoo.define("terminal.Terminal", function (require) {
             // Try alias
             let alias_cmd = this.getAliasCommand(cmd_name);
             if (alias_cmd) {
-                const scmd = this._parameterReader.parse(cmd, {args: "*"});
+                const scmd = this._parameterReader.parse(cmd);
                 const params_len = scmd.params.length;
                 let index = 0;
                 while (index < params_len) {
@@ -686,7 +685,7 @@ odoo.define("terminal.Terminal", function (require) {
                         def: cmd_def,
                         jobIndex: job_index,
                     };
-                    result = await cmd_def.callback.apply(this, scmd.params);
+                    result = await cmd_def.callback.call(this, scmd.params);
                     delete this.__meta;
                 } catch (err) {
                     is_failed = true;
@@ -767,8 +766,8 @@ odoo.define("terminal.Terminal", function (require) {
                 );
                 if (
                     typeof result === "object" &&
-                    !("data" in result) &&
-                    "message" in result
+                    !Object.prototype.hasOwnProperty.call(result, "data") &&
+                    Object.prototype.hasOwnProperty.call(result, "message")
                 ) {
                     this.screen.printError(result.message, true);
                 } else {

--- a/page_script.js
+++ b/page_script.js
@@ -79,7 +79,7 @@
      * @param {Function} on_rejected
      */
     function _createRpc(url, fct_name, params, on_fulfilled, on_rejected) {
-        if (!("args" in params)) {
+        if (!Object.prototype.hasOwnProperty.call(params, "args")) {
             params.args = {};
         }
 

--- a/page_script.js
+++ b/page_script.js
@@ -45,32 +45,28 @@
      * @param {String} ver - Odoo version
      */
     function _setServerVersion(ver) {
-        gOdooInfo.serverVersion = ver;
-        const foundVer = gOdooInfo.serverVersion.match(/\d+/);
+        gOdooInfo.serverVersionRaw = ver;
+        const foundVer = gOdooInfo.serverVersionRaw.match(
+            /(\d+)\.(\d+)(?:([a-z]+)(\d*))?/
+        );
         if (foundVer && foundVer.length) {
-            gOdooInfo.serverVersionMajor = foundVer[0];
+            gOdooInfo.serverVersion = {
+                major: Number(foundVer[1]),
+                minor: Number(foundVer[2]),
+                status: foundVer[3],
+                statusLevel: foundVer[4] && Number(foundVer[4]),
+            };
         }
         const cvers = COMPATIBLE_VERS.filter(function (item) {
-            return gOdooInfo.serverVersion.startsWith(item);
+            return gOdooInfo.serverVersionRaw.startsWith(item);
         });
         if (cvers.length) {
             gOdooInfo.isCompatible = true;
-            window.term_odooVersion = gOdooInfo.serverVersion;
-            window.term_odooVersionMajor = gOdooInfo.serverVersionMajor;
-        } else {
-            if (
-                Object.prototype.hasOwnProperty.call(window, "term_odooVersion")
-            ) {
-                delete window.term_odooVersion;
-            }
-            if (
-                Object.prototype.hasOwnProperty.call(
-                    window,
-                    "term_odooVersionMajor"
-                )
-            ) {
-                delete window.term_odooVersionMajor;
-            }
+            window.term_odooVersionRaw = gOdooInfo.serverVersionRaw;
+        } else if (
+            Object.prototype.hasOwnProperty.call(window, "term_odooVersionRaw")
+        ) {
+            delete window.term_odooVersionRaw;
         }
     }
 
@@ -126,7 +122,7 @@
                     (rpc_response) => {
                         const version = rpc_response.result;
                         if (
-                            !_.isUndefined(version) &&
+                            typeof version !== "undefined" &&
                             typeof version === "string"
                         ) {
                             _setServerVersion(version);
@@ -147,8 +143,9 @@
      * @returns {Boolean}
      */
     function _forceIsOdooBackendDetection() {
-        return _.isNull(
-            document.querySelector("head script[src*='assets_frontend']")
+        return (
+            document.querySelector("head script[src*='assets_frontend']") ===
+            null
         );
     }
 

--- a/settings/options.css
+++ b/settings/options.css
@@ -3,12 +3,6 @@ body {
     padding: 1em;
 }
 
-textarea {
-    height: 200px;
-    white-space: pre;
-    width: 100%;
-}
-
 .btn_zone {
     margin-top: 1em;
     text-align: right;
@@ -16,4 +10,23 @@ textarea {
 
 .btn_zone > button {
     padding: 0.5em;
+}
+
+.optsection textarea {
+    height: 200px;
+    white-space: pre;
+    width: 98%;
+}
+
+.optsection {
+    border: 1px solid gray;
+    padding: 0.3em;
+}
+
+.optsection:not(:first-child) {
+    margin-top: 0.5em;
+}
+
+.optsection h4 {
+    margin: 0;
 }

--- a/settings/options.html
+++ b/settings/options.html
@@ -7,9 +7,12 @@
 
   <body>
     <form>
-      <h4>Init Commands</h4>
-      <p>Run these commands when initialize the terminal (one per line)</p>
-      <textarea id="init_cmds"></textarea>
+      <div class="optsection">
+        <h4>Init Commands</h4>
+        <p>Run these commands when initialize the terminal (one per line)</p>
+        <textarea id="init_cmds"></textarea>
+      </div>
+
       <div class="btn_zone">
         <button type="submit">Save</button>
       </div>

--- a/settings/options.js
+++ b/settings/options.js
@@ -14,7 +14,7 @@
     }
 
     function _onDOMLoaded() {
-        gBrowserObj.storage.sync.get(["init_cmds"], (result) => {
+        gBrowserObj.storage.sync.get(["init_cmds", "lang"], (result) => {
             document.querySelector("#init_cmds").value = result.init_cmds || "";
         });
 

--- a/settings/options.js
+++ b/settings/options.js
@@ -14,7 +14,7 @@
     }
 
     function _onDOMLoaded() {
-        gBrowserObj.storage.sync.get(["init_cmds", "lang"], (result) => {
+        gBrowserObj.storage.sync.get(["init_cmds"], (result) => {
             document.querySelector("#init_cmds").value = result.init_cmds || "";
         });
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,10 +13,10 @@ class SeleniumTestCase(unittest.TestCase):
 
     _ODOO_SERVERS = {
         'ce': {
-            '11': 'https://runbot.odoo-community.org/runbot/189/11.0',
-            '12': 'https://runbot.odoo-community.org/runbot/189/12.0',
-            '13': 'https://runbot.odoo-community.org/runbot/189/13.0',
-            '14': 'https://runbot.odoo-community.org/runbot/189/14.0',
+            '11': 'https://runbot.odoo-community.org/runbot/142/11.0',
+            '12': 'https://runbot.odoo-community.org/runbot/142/12.0',
+            '13': 'https://runbot.odoo-community.org/runbot/142/13.0',
+            '14': 'https://runbot.odoo-community.org/runbot/142/14.0',
         },
         # 'ee': {
         #     '11': 'http://runbot.odoo.com/runbot/quick_connect/33836',


### PR DESCRIPTION
IMP: Screen: reflows
IMP: Parameter reader: support json parameter
IMP: Command 'caf': hightlight required fields and new argument to apply a filter
IMP: Command 'help': More verbose format
IMP: Command 'login': Now uses '#' instead of '-'
IMP: Command 'repeat': New argument '--silent'
IMP: Support with "master" branch (pre 15.0)
IMP: ParamaterReader: Now supports 'named arguments'
IMP: Command definition: Rework 'args' and removed unused properties (syntax)

ADD: Command 'lang': Operations over translations (issue #30)
ADD: 'delete' option to 'context' and 'context_term' commands
ADD: Command Assistant

FIX: Disable 'native autocomplete' in chrome

DEL: Command 'mute'. Now is part of the execution implementation