### PR TITLE
fix: avoid load in 'alpha', 'beta' versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+**9.2.1**
+
+```
+FIX: Avoid load in 'alpha', 'beta' versions (issue #99)
+```
+
 **9.2.0**
 
 ```

--- a/page_script.js
+++ b/page_script.js
@@ -14,6 +14,7 @@
     }
     window.hasRun = true;
 
+    const DEVELOPER_MODE = false;
     const COMPATIBLE_VERS = [
         "11.",
         "saas~11",
@@ -63,8 +64,16 @@
             };
         }
         const cvers = COMPATIBLE_VERS.filter(function (item) {
-            return gOdooInfo.serverVersionRaw.startsWith(item);
+            if (DEVELOPER_MODE) {
+                return gOdooInfo.serverVersionRaw.startsWith(item);
+            }
+            return (
+                gOdooInfo.serverVersionRaw.startsWith(item) &&
+                !gOdooInfo.serverVersionRaw.includes("alpha") &&
+                !gOdooInfo.serverVersionRaw.includes("beta")
+            );
         });
+
         if (cvers.length) {
             gOdooInfo.isCompatible = true;
             window.term_odooVersionRaw = gOdooInfo.serverVersionRaw;


### PR DESCRIPTION
Fix #99