### PR TITLE
[IMP] Enable the compatibility with odoo v18.x

### DIFF
--- a/src/js/common/constants.mjs
+++ b/src/js/common/constants.mjs
@@ -156,8 +156,8 @@ export const COMPATIBLE_VERSIONS: $ReadOnlyArray<string> = [
   'saas~16',
   '17.',
   'saas~17',
-  '18.0',
-  'saas~18.0',
+  '18.',
+  'saas~18',
 ];
 
 export const THEMES: $ReadOnlyArray<[string, string]> = [


### PR DESCRIPTION
- I enabled the access to the terminal for Odoo SaaS users (v18.2 as of now)