### PR TITLE
[FIX] Typo in the technical documentation details

### DIFF
--- a/_locales/en/translation.json
+++ b/_locales/en/translation.json
@@ -281,8 +281,8 @@
       "method": "The method name",
       "model": "The model technical name"
     },
-    "definition": "Open thecnical documentation page",
-    "detail": "Open thecnical documentation page.",
+    "definition": "Open technical documentation page",
+    "detail": "Open technical documentation page.",
     "error": {
       "incompatibleOdooVersion": "This command is only available in Odoo 19.0+"
     }

--- a/src/js/page/odoo/commands/backoffice/doc.mjs
+++ b/src/js/page/odoo/commands/backoffice/doc.mjs
@@ -48,10 +48,10 @@ async function getOptions(this: Terminal, arg_name: string) {
 
 export default function (): Partial<CMDDef> {
   return {
-    definition: i18n.t('cmdDoc.definition', 'Open thecnical documentation page'),
+    definition: i18n.t('cmdDoc.definition', 'Open technical documentation page'),
     callback: cmdDoc,
     options: getOptions,
-    detail: i18n.t('cmdDoc.detail', 'Open thecnical documentation page.'),
+    detail: i18n.t('cmdDoc.detail', 'Open technical documentation page.'),
     args: [
       [
         ARG.String,


### PR DESCRIPTION
Found a typo in the new v19 feature