### PR TITLE
new command added: update_apps_list

### DIFF
--- a/README-how-to-install.md
+++ b/README-how-to-install.md
@@ -1,0 +1,18 @@
+if this fork PR is not accepted yet, you can compile it your self, then use it on your own browser. here is how:
+
+1. clone this repo to your-project-directory
+2. cd your-project-directory
+3. npm install
+4. npm run prod:build
+
+5. now open your browser
+   - if chrome: go to manage extension
+   - click Load Unpacked on the top left
+   - select your-project-directory
+   - done
+
+6. now you can go to your odoo website, and try the new Odoo Terminal
+
+common issue:
+
+1. command update_apps_list is unknown solution: you might need to uninstall the old Odoo Terminal first

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You can toggle terminal using one of these options:
 | View 'res.partner' records _(only backend)_         | `view -m res.partner`                                                 |
 | View selected 'res.partner' record _(only backend)_ | `view -m res.partner -i 4`                                            |
 | Install module                                      | `install -m mymodule`                                                 |
+| Update Apps List                                    | `update_apps_list`                                                    |
 | Create alias                                        | `alias -n myalias -c "print 'My name is: $1'"`                        |
 
 > Notice that a list is an string of values separated by commas. Example: "5, 15, 8" (quotes included) or can use array

--- a/_locales/en/translation.json
+++ b/_locales/en/translation.json
@@ -791,6 +791,12 @@
       "success": "{{model}} record deleted successfully"
     }
   },
+  "cmdUpdateAppsList": {
+    "definition": "Update apps list",
+    "detail": "Refresh available modules list.",
+    "error": "Failed to update apps list",
+    "success": "Apps list successfully updated"
+  },
   "cmdUpgrade": {
     "args": {
       "module": "The module technical name"

--- a/_locales/es/translation.json
+++ b/_locales/es/translation.json
@@ -791,6 +791,12 @@
       "success": "{{model}} registro eliminado correctamente"
     }
   },
+  "cmdUpdateAppsList": {
+    "definition": "Update apps list",
+    "detail": "Refresh available modules list.",
+    "error": "Failed to update apps list",
+    "success": "Apps list successfully updated"
+  },
   "cmdUpgrade": {
     "args": {
       "module": "El nombre técnico del módulo"

--- a/src/js/page/odoo/commands/common/__all__.mjs
+++ b/src/js/page/odoo/commands/common/__all__.mjs
@@ -39,6 +39,7 @@ import cmdUhg from './uhg';
 import cmdUninstall from './uninstall';
 import cmdUnlink from './unlink';
 import cmdUpgrade from './upgrade';
+import cmdUpdateAppsList from './update_apps_list';
 import cmdVersion from './version';
 import cmdWhoami from './whoami';
 import cmdWrite from './write';
@@ -58,6 +59,7 @@ export default function (vm: VMachine) {
   vm.registerCommand('search', cmdSearch());
   vm.registerCommand('call', cmdCall());
   vm.registerCommand('upgrade', cmdUpgrade());
+  vm.registerCommand('update_apps_list', cmdUpdateAppsList());
   vm.registerCommand('install', cmdInstall());
   vm.registerCommand('uninstall', cmdUninstall());
   vm.registerCommand('reload', cmdReload());

--- a/src/js/page/odoo/commands/common/update_apps_list.mjs
+++ b/src/js/page/odoo/commands/common/update_apps_list.mjs
@@ -1,0 +1,37 @@
+// @flow strict
+import i18n from 'i18next';
+import callModel from '@odoo/osv/call_model';
+import type {CMDCallbackContext, CMDDef} from '@trash/interpreter';
+import type Terminal from '@odoo/terminal';
+
+async function cmdUpdateAppsList(this: Terminal, kwargs: any, ctx: CMDCallbackContext) {
+  try {
+    debugger;
+    await callModel(
+      'ir.module.module',
+      'update_list',
+      [],
+      {},
+      await this.getContext(),
+    );
+
+    ctx.screen.print(
+      i18n.t('cmdUpdateAppsList.success', 'Apps list successfully updated'),
+    );
+  } catch (err) {
+    throw new Error(
+      err?.message ||
+      i18n.t('cmdUpdateAppsList.error', 'Failed to update apps list'),
+    );
+  }
+}
+
+export default function (): Partial<CMDDef> {
+  return {
+    definition: i18n.t('cmdUpdateAppsList.definition', 'Update apps list'),
+    callback: cmdUpdateAppsList,
+    detail: i18n.t('cmdUpdateAppsList.detail', 'Refresh available modules list.'),
+    args: [],
+    example: '',
+  };
+}


### PR DESCRIPTION
sometime before even you can run "install module"
you have to update the apps list first.
this PR is adding a new command "update_apps_list" 
it will update the apps list, so you don't have to do it manually via apps module.